### PR TITLE
add skill-creator skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The CLI guides you through an interactive installation:
 4. **Installation method** - Symlink (recommended) or Copy
 
 ```
-◇  Found 8 skills
+◇  Found 9 skills
 │
 ◆  Select skills to install
 │  ◼ apollo-client
@@ -372,6 +372,44 @@ npx skills add apollographql/skills --skill rust-best-practices
 [Performance](skills/rust-best-practices/references/performance.md) ·
 [Testing](skills/rust-best-practices/references/testing.md) ·
 [Advanced](skills/rust-best-practices/references/advanced.md)
+
+---
+
+### skill-creator
+
+Guide for creating effective skills for Apollo GraphQL and GraphQL development.
+
+**Install:**
+
+```bash
+npx skills add apollographql/skills --skill skill-creator
+```
+
+**Use when:**
+
+- Creating a new skill for this repository
+- Updating an existing skill's structure or content
+- Learning skill best practices and patterns
+- Writing SKILL.md files or reference documentation
+
+**Categories covered:**
+
+- SKILL.md format and frontmatter fields
+- Directory structure and reference files
+- Description writing for agent activation triggers
+- Progressive disclosure and context optimization
+- Apollo Voice writing style guidelines
+- Validation checklist for new skills
+
+**Examples:**
+
+- "Create a new skill for Apollo Federation"
+- "Help me write a SKILL.md for my custom skill"
+- "Review my skill structure for best practices"
+
+**References:**
+[SKILL.md](skills/skill-creator/SKILL.md) ·
+[Apollo Skills](skills/skill-creator/references/apollo-skills.md)
 
 ---
 

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -1,0 +1,252 @@
+---
+name: skill-creator
+description: >
+  Guide for creating effective skills for Apollo GraphQL and GraphQL development. Use this skill when:
+  (1) users want to create a new skill,
+  (2) users want to update an existing skill,
+  (3) users ask about skill structure or best practices,
+  (4) users need help writing SKILL.md files.
+license: MIT
+compatibility: Works with Claude Code and similar AI coding assistants that support Agent Skills.
+metadata:
+  author: apollographql
+  version: "1.0"
+allowed-tools: Read Write Edit Glob Grep
+---
+
+# Skill Creator Guide
+
+This guide helps you create effective skills for Apollo GraphQL and GraphQL development following the [Agent Skills specification](https://agentskills.io/specification).
+
+## What is a Skill?
+
+A skill is a directory containing instructions that extend an AI agent's capabilities with specialized knowledge, workflows, or tool integrations. Skills activate automatically when agents detect relevant tasks.
+
+## Directory Structure
+
+A skill requires at minimum a `SKILL.md` file:
+
+```
+skill-name/
+├── SKILL.md              # Required - main instructions
+└── references/           # Optional - detailed documentation
+    ├── topic-a.md
+    └── topic-b.md
+```
+
+## SKILL.md Format
+
+### Frontmatter (Required)
+
+```yaml
+---
+name: skill-name
+description: >
+  A clear description of what this skill does and when to use it.
+  Include trigger conditions: (1) first condition, (2) second condition.
+license: MIT
+compatibility: Works with Claude Code and similar AI coding assistants.
+metadata:
+  author: your-org
+  version: "1.0"
+allowed-tools: Read Write Edit Glob Grep
+---
+```
+
+### Frontmatter Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Lowercase, hyphens only. Must match directory name. Max 64 chars. |
+| `description` | Yes | What the skill does and when to use it. Max 1024 chars. |
+| `license` | No | License name (e.g., MIT, Apache-2.0). |
+| `compatibility` | No | Environment requirements. Max 500 chars. |
+| `metadata` | No | Key-value pairs for author, version, etc. |
+| `allowed-tools` | No | Space-delimited list of pre-approved tools. |
+
+### Name Rules
+
+- Use lowercase letters, numbers, and hyphens only
+- Do not start or end with a hyphen
+- Do not use consecutive hyphens (`--`)
+- Must match the parent directory name
+
+Good: `apollo-client`, `graphql-schema`, `rover`
+Bad: `Apollo-Client`, `-apollo`, `apollo--client`
+
+### Description Best Practices
+
+Write descriptions that help agents identify when to activate the skill:
+
+```yaml
+# Good - specific triggers and use cases
+description: >
+  Guide for designing GraphQL schemas following industry best practices. Use this skill when:
+  (1) designing a new GraphQL schema or API,
+  (2) reviewing existing schema for improvements,
+  (3) deciding on type structures or nullability,
+  (4) implementing pagination or error patterns.
+
+# Bad - vague and unhelpful
+description: Helps with GraphQL stuff.
+```
+
+## Body Content
+
+The markdown body contains instructions the agent follows. Structure it for clarity:
+
+### Recommended Sections
+
+1. **Overview** - Brief explanation of the skill's purpose
+2. **Process** - Step-by-step workflow (use checkboxes for multi-step processes)
+3. **Quick Reference** - Common patterns and syntax
+4. **Reference Files** - Links to detailed documentation
+5. **Key Rules** - Important guidelines organized by topic
+6. **Ground Rules** - Critical do's and don'ts
+
+### Example Structure
+
+```markdown
+# Skill Title
+
+Brief overview of what this skill helps with.
+
+## Process
+
+Follow this process when working on [task]:
+
+- [ ] Step 1: Research and understand requirements
+- [ ] Step 2: Implement the solution
+- [ ] Step 3: Validate the result
+
+## Quick Reference
+
+### Common Pattern
+
+\`\`\`graphql
+type Example {
+  id: ID!
+  name: String
+}
+\`\`\`
+
+## Reference Files
+
+- [Topic A](references/topic-a.md) - Detailed guide for topic A
+- [Topic B](references/topic-b.md) - Detailed guide for topic B
+
+## Key Rules
+
+### Category One
+
+- Rule about this category
+- Another rule
+
+### Category Two
+
+- Rule about this category
+
+## Ground Rules
+
+- ALWAYS do this important thing
+- NEVER do this problematic thing
+- PREFER this approach over that approach
+```
+
+## Progressive Disclosure
+
+Structure skills to minimize context usage:
+
+1. **Metadata** (~100 tokens): `name` and `description` load at startup for all skills
+2. **Instructions** (< 5000 tokens): Full `SKILL.md` loads when skill activates
+3. **References** (as needed): Files in `references/` load only when required
+
+Keep `SKILL.md` under 500 lines. Move detailed documentation to reference files.
+
+## Reference Files
+
+Use `references/` for detailed documentation:
+
+```
+references/
+├── setup.md          # Installation and configuration
+├── patterns.md       # Common patterns and examples
+├── troubleshooting.md # Error solutions
+└── api.md            # API reference
+```
+
+Reference files should be:
+
+- Focused on a single topic
+- Self-contained (readable without other files)
+- Under 300 lines each
+
+Link to references from `SKILL.md`:
+
+```markdown
+## Reference Files
+
+- [Setup](references/setup.md) - Installation and configuration
+- [Patterns](references/patterns.md) - Common patterns and examples
+```
+
+## Writing Style
+
+Follow the Apollo Voice for all skill content:
+
+### Tone
+
+- Approachable and helpful
+- Opinionated and authoritative (prescribe the "happy path")
+- Direct and action-oriented
+
+### Language
+
+- Use American English
+- Keep language simple; avoid idioms
+- Use present tense and active voice
+- Use imperative verbs for instructions
+
+### Formatting
+
+- Use sentence casing for headings
+- Use code font for symbols, commands, file paths, and URLs
+- Use bold for UI elements users click
+- Use hyphens (-) for unordered lists
+
+### Avoid
+
+- "Simply", "just", "easy" (can be condescending)
+- Vague phrases like "click here"
+- Semicolons (use periods instead)
+- "We" unless clearly referring to Apollo
+
+## Reference Files
+
+For Apollo GraphQL-specific guidance:
+
+- [Apollo Skills](references/apollo-skills.md) - Patterns and examples for Apollo GraphQL skills
+
+## Checklist for New Skills
+
+Before publishing a skill, verify:
+
+- [ ] `name` matches directory name and follows naming rules
+- [ ] `description` clearly states what the skill does and when to use it
+- [ ] `SKILL.md` is under 500 lines
+- [ ] Reference files are focused and under 300 lines each
+- [ ] Instructions are clear and actionable
+- [ ] Code examples are correct and tested
+- [ ] Ground rules use ALWAYS/NEVER/PREFER format
+- [ ] Content follows Apollo Voice guidelines
+
+## Ground Rules
+
+- ALWAYS include trigger conditions in the description (use numbered list)
+- ALWAYS use checkboxes for multi-step processes
+- ALWAYS link to reference files for detailed documentation
+- NEVER exceed 500 lines in SKILL.md
+- NEVER use vague descriptions that don't help agents identify when to activate
+- PREFER specific examples over abstract explanations
+- PREFER opinionated guidance over listing multiple options
+- USE `allowed-tools` to pre-approve tools the skill needs

--- a/skills/skill-creator/references/apollo-skills.md
+++ b/skills/skill-creator/references/apollo-skills.md
@@ -1,0 +1,199 @@
+# Creating Apollo GraphQL Skills
+
+This guide provides specific guidance for creating skills in the Apollo GraphQL skills repository.
+
+## Repository Structure
+
+Apollo skills live in the `skills/` directory:
+
+```
+skills/
+├── apollo-client/
+├── apollo-connectors/
+├── apollo-server/
+├── graphql-schema/
+└── your-new-skill/
+```
+
+## Skill Categories
+
+### Product Skills
+
+Skills for specific Apollo products:
+
+- `apollo-client` - Apollo Client for React/web applications
+- `apollo-server` - Apollo Server setup and configuration
+- `apollo-connectors` - REST API integration with Connectors
+- `apollo-mcp-server` - MCP Server for AI agents
+- `rover` - Rover CLI for graph management
+
+### Convention Skills
+
+Skills for GraphQL conventions and best practices:
+
+- `graphql-schema` - Schema design patterns
+- `graphql-operations` - Query and mutation patterns
+
+## Description Patterns
+
+Use consistent trigger patterns in descriptions:
+
+```yaml
+# Product skill pattern
+description: >
+  Help users build [what] with [product]. Use this skill when:
+  (1) setting up [product] in a new project,
+  (2) implementing [common feature],
+  (3) troubleshooting [product] errors,
+  (4) working with files containing [identifier].
+
+# Convention skill pattern
+description: >
+  Guide for [topic] following industry best practices. Use this skill when:
+  (1) designing new [thing],
+  (2) reviewing existing [thing] for improvements,
+  (3) implementing [pattern],
+  (4) ensuring [quality aspect].
+```
+
+## MCP Tool Integration
+
+If GraphOS MCP tools are available, reference them in your skill:
+
+```markdown
+## MCP Tools
+
+If GraphOS MCP Tools are available, use them:
+- **apollo_docs_search**: Search for relevant documentation
+- **apollo_docs_read**: Read specific documentation pages by slug
+
+**Documentation paths by topic:**
+- Topic A: `/graphos/path/to/topic-a`
+- Topic B: `/graphos/path/to/topic-b`
+```
+
+## Process Structure
+
+Use a consistent process structure with checkboxes:
+
+```markdown
+## Process
+
+Follow this process. **DO NOT skip any steps.**
+
+### Step 1: Research
+
+- [ ] Understand the requirements
+- [ ] Ask the user for clarification if needed
+- [ ] Fetch relevant documentation
+- [ ] DO NOT write code until research is complete
+
+### Step 2: Implement
+
+- [ ] Create the solution using patterns below
+- [ ] Follow the reference files for detailed guidance
+
+### Step 3: Validate
+
+- [ ] Run validation commands
+- [ ] Fix any errors before proceeding
+
+### Step 4: Test
+
+- [ ] Create or update tests
+- [ ] Verify the solution works correctly
+```
+
+## Code Examples
+
+### GraphQL Schema Examples
+
+```graphql
+"""
+A user in the system.
+"""
+type User {
+  id: ID!
+  email: String!
+  name: String
+  posts(first: Int = 10, after: String): PostConnection!
+}
+```
+
+### TypeScript Examples
+
+```typescript
+import { ApolloClient, InMemoryCache } from '@apollo/client';
+
+const client = new ApolloClient({
+  uri: 'https://api.example.com/graphql',
+  cache: new InMemoryCache(),
+});
+```
+
+### Rover CLI Examples
+
+```bash
+# Publish a subgraph
+rover subgraph publish my-graph@current \
+  --name products \
+  --schema ./schema.graphql
+
+# Run local development
+rover dev --supergraph-config supergraph.yaml
+```
+
+## Reference File Organization
+
+Organize reference files by topic:
+
+```
+references/
+├── setup.md           # Installation and quick start
+├── queries.md         # Query patterns (for client skills)
+├── mutations.md       # Mutation patterns (for client skills)
+├── resolvers.md       # Resolver patterns (for server skills)
+├── caching.md         # Cache configuration
+├── error-handling.md  # Error handling patterns
+└── troubleshooting.md # Common errors and solutions
+```
+
+## Ground Rules Format
+
+Use consistent formatting for ground rules:
+
+```markdown
+## Ground Rules
+
+- NEVER make up syntax not in the specification
+- NEVER skip validation steps
+- ALWAYS ask for clarification when requirements are unclear
+- ALWAYS validate with appropriate commands after changes
+- PREFER [recommended approach] over [alternative]
+- USE [tool/pattern] for [specific use case]
+```
+
+## Documentation Links
+
+Include links to official Apollo documentation:
+
+```markdown
+## Resources
+
+- [Apollo Client Documentation](https://www.apollographql.com/docs/react/)
+- [Apollo Server Documentation](https://www.apollographql.com/docs/apollo-server/)
+- [Apollo Connectors Documentation](https://www.apollographql.com/docs/graphos/schema-design/connectors/)
+- [Rover CLI Documentation](https://www.apollographql.com/docs/rover/)
+```
+
+## Validation Checklist
+
+Before submitting a new Apollo skill:
+
+- [ ] Skill follows the Agent Skills specification
+- [ ] Description includes numbered trigger conditions
+- [ ] Code examples use current API versions
+- [ ] Commands include required flags and options
+- [ ] Error messages reference troubleshooting guide
+- [ ] Links to official Apollo documentation are correct
+- [ ] Content follows Apollo Voice guidelines


### PR DESCRIPTION
Adds a new Skill that guides contributors when creating or updating Skills for Apollo GraphQL and GraphQL development. The skill provides comprehensive documentation on the Agent Skills specification, including SKILL.md format, frontmatter fields, directory structure, and progressive disclosure patterns. It also covers Apollo Voice writing guidelines to ensure consistent tone across all skills in this repository.

<img width="1300" height="432" alt="2026-01-29 at 10 34 01" src="https://github.com/user-attachments/assets/5ca02430-ef9e-434a-a406-3761b0ddacb4" />
