### PR TITLE
feat: add apollo-router skill for federated GraphQL supergraphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,49 @@ npx skills add apollographql/skills@apollo-mcp-server
 
 ---
 
+### apollo-router
+
+Configure and run Apollo Router for federated GraphQL supergraphs.
+
+**Install:**
+
+```bash
+npx skills add apollographql/skills@apollo-router
+```
+
+**Use when:**
+
+- Setting up Apollo Router to run a supergraph
+- Configuring routing, headers, or CORS
+- Implementing custom plugins (Rhai scripts or coprocessors)
+- Configuring telemetry and observability
+- Troubleshooting Router performance or connectivity issues
+
+**Categories covered:**
+
+- Installation and quick start
+- Router configuration (YAML)
+- Header propagation and manipulation
+- CORS and authentication
+- Rhai scripts and coprocessors
+- Telemetry (tracing, metrics, logging)
+
+**Examples:**
+
+- "Set up Apollo Router for my supergraph"
+- "Configure CORS for my Router"
+- "Add header propagation for authentication"
+
+**References:**
+[SKILL.md](skills/apollo-router/SKILL.md) ·
+[Configuration](skills/apollo-router/references/configuration.md) ·
+[Headers](skills/apollo-router/references/headers.md) ·
+[Plugins](skills/apollo-router/references/plugins.md) ·
+[Telemetry](skills/apollo-router/references/telemetry.md) ·
+[Troubleshooting](skills/apollo-router/references/troubleshooting.md)
+
+---
+
 ### apollo-server
 
 Build GraphQL servers with Apollo Server 4.x, including schemas, resolvers, authentication, and plugins.

--- a/skills/apollo-router/SKILL.md
+++ b/skills/apollo-router/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: apollo-router
+description: >
+  Guide for configuring and running Apollo Router for federated GraphQL supergraphs. Use this skill when:
+  (1) setting up Apollo Router to run a supergraph,
+  (2) configuring routing, headers, or CORS,
+  (3) implementing custom plugins (Rhai scripts or coprocessors),
+  (4) configuring telemetry (tracing, metrics, logging),
+  (5) troubleshooting Router performance or connectivity issues.
+license: MIT
+compatibility: Linux/macOS/Windows. Requires a composed supergraph schema from Rover or GraphOS.
+metadata:
+  author: apollographql
+  version: "1.0"
+allowed-tools: Bash(router:*) Bash(./router:*) Bash(rover:*) Bash(curl:*) Bash(docker:*) Read Write Edit Glob Grep
+---
+
+# Apollo Router Guide
+
+Apollo Router is a high-performance graph router written in Rust for running Apollo Federation 2 supergraphs. It sits in front of your subgraphs and handles query planning, execution, and response composition.
+
+## Quick Start
+
+### Step 1: Install
+
+```bash
+# macOS/Linux
+curl -sSL https://router.apollo.dev/download/nix/latest | sh
+
+# Move to PATH
+sudo mv router /usr/local/bin/
+
+# Verify installation
+router --version
+```
+
+Docker:
+```bash
+docker pull ghcr.io/apollographql/router:latest
+```
+
+### Step 2: Get a Supergraph Schema
+
+Create with Rover:
+```bash
+# Compose from local files
+rover supergraph compose --config supergraph.yaml > supergraph.graphql
+
+# Or fetch from GraphOS
+rover supergraph fetch my-graph@production > supergraph.graphql
+```
+
+### Step 3: Run the Router
+
+```bash
+# With local schema
+router --supergraph supergraph.graphql
+
+# With configuration file
+router --supergraph supergraph.graphql --config router.yaml
+
+# Development mode (relaxed security, better errors)
+router --dev --supergraph supergraph.graphql
+```
+
+Default endpoint: `http://localhost:4000`
+
+## Configuration Overview
+
+Create `router.yaml` to configure the Router:
+
+```yaml
+# Listen address
+supergraph:
+  listen: 127.0.0.1:4000
+  introspection: true
+
+# Enable GraphQL Sandbox
+sandbox:
+  enabled: true
+
+# Header propagation
+headers:
+  all:
+    request:
+      - propagate:
+          matching: "^x-.*"
+
+# CORS configuration
+cors:
+  origins:
+    - http://localhost:3000
+  allow_headers:
+    - Content-Type
+    - Authorization
+```
+
+## Running Modes
+
+| Mode | Command | Use Case |
+|------|---------|----------|
+| Local schema | `router --supergraph ./schema.graphql` | Development, CI/CD |
+| GraphOS managed | `APOLLO_KEY=... APOLLO_GRAPH_REF=my-graph@prod router` | Production with auto-updates |
+| Development | `router --dev --supergraph ./schema.graphql` | Local development |
+| Hot reload | `router --hot-reload --supergraph ./schema.graphql` | Schema changes without restart |
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `APOLLO_KEY` | API key for GraphOS |
+| `APOLLO_GRAPH_REF` | Graph reference (`graph-id@variant`) |
+| `APOLLO_ROUTER_CONFIG_PATH` | Path to `router.yaml` |
+| `APOLLO_ROUTER_SUPERGRAPH_PATH` | Path to supergraph schema |
+| `APOLLO_ROUTER_LOG` | Log level (off, error, warn, info, debug, trace) |
+| `APOLLO_ROUTER_LISTEN_ADDRESS` | Override listen address |
+
+## Reference Files
+
+Detailed documentation for specific topics:
+
+- [Configuration](references/configuration.md) - YAML configuration reference
+- [Headers](references/headers.md) - Header propagation and manipulation
+- [Plugins](references/plugins.md) - Rhai scripts and coprocessors
+- [Telemetry](references/telemetry.md) - Tracing, metrics, and logging
+- [Troubleshooting](references/troubleshooting.md) - Common issues and solutions
+
+## Common Patterns
+
+### Production Deployment
+
+```yaml
+# router.yaml for production
+supergraph:
+  listen: 0.0.0.0:4000
+  introspection: false
+
+sandbox:
+  enabled: false
+
+telemetry:
+  exporters:
+    tracing:
+      otlp:
+        enabled: true
+        endpoint: http://collector:4317
+
+include_subgraph_errors:
+  all: false
+```
+
+### With Docker
+
+```bash
+docker run -p 4000:4000 \
+  -v ./supergraph.graphql:/etc/router/supergraph.graphql \
+  -v ./router.yaml:/etc/router/router.yaml \
+  ghcr.io/apollographql/router:latest \
+  --supergraph /etc/router/supergraph.graphql \
+  --config /etc/router/router.yaml
+```
+
+### GraphOS Managed
+
+```bash
+export APOLLO_KEY=service:my-graph:key
+export APOLLO_GRAPH_REF=my-graph@production
+router
+```
+
+The Router automatically fetches and updates the supergraph schema from GraphOS.
+
+## CLI Reference
+
+```
+router [OPTIONS]
+
+Options:
+  -s, --supergraph <PATH>    Path to supergraph schema file
+  -c, --config <PATH>        Path to router.yaml configuration
+      --dev                  Enable development mode
+      --hot-reload           Watch for schema changes
+      --log <LEVEL>          Log level (default: info)
+      --listen <ADDRESS>     Override listen address
+  -V, --version              Print version
+  -h, --help                 Print help
+```
+
+## Ground Rules
+
+- ALWAYS use `--dev` mode for local development (enables introspection and sandbox)
+- ALWAYS disable introspection and sandbox in production
+- PREFER GraphOS managed mode for production (automatic updates, metrics)
+- USE `--hot-reload` for local development with file-based schemas
+- NEVER expose `APOLLO_KEY` in logs or version control
+- USE environment variables for sensitive configuration
+- PREFER YAML configuration over command-line arguments for complex setups
+- TEST configuration changes locally before deploying to production

--- a/skills/apollo-router/SKILL.md
+++ b/skills/apollo-router/SKILL.md
@@ -11,7 +11,7 @@ license: MIT
 compatibility: Linux/macOS/Windows. Requires a composed supergraph schema from Rover or GraphOS.
 metadata:
   author: apollographql
-  version: "1.0"
+  version: "1.0.0"
 allowed-tools: Bash(router:*) Bash(./router:*) Bash(rover:*) Bash(curl:*) Bash(docker:*) Read Write Edit Glob Grep
 ---
 

--- a/skills/apollo-router/divergence-map.md
+++ b/skills/apollo-router/divergence-map.md
@@ -1,0 +1,90 @@
+# Apollo Router v1 ↔ v2 Config Divergence Map
+
+This document tracks every configuration section where v1 and v2 schemas differ
+in ways that break parsing or change behavior. All templates in this skill branch
+on these differences.
+
+## CORS
+
+| Aspect | v1 | v2 |
+|--------|----|----|
+| Origins | `cors.origins: [...]` (flat list) | `cors.policies: [{ origins: [...] }]` (array of policy objects) |
+| Headers | `cors.allow_headers` | Same key, but inside each policy or at global level |
+| Methods | `cors.methods` | Same, inheritable per-policy |
+| Max Age | Duration string (for example: `cors.max_age: 24h`) | Same format (duration string) |
+| Credentials | `cors.allow_credentials` | Same, inheritable per-policy |
+
+See: [templates/v1/sections/cors.yaml](templates/v1/sections/cors.yaml) vs [templates/v2/sections/cors.yaml](templates/v2/sections/cors.yaml)
+
+## JWT Authentication
+
+| Aspect | v1 | v2 |
+|--------|----|----|
+| Issuer field | `issuer: <string>` (singular) | `issuers: [<string>, ...]` (plural, array) |
+| Poll interval | `poll_interval` supported | Same |
+
+> [!CAUTION]
+> `issuer` is a v1 field. In v2, always use `issuers` (array).
+
+See: [templates/v1/sections/auth.yaml](templates/v1/sections/auth.yaml) vs [templates/v2/sections/auth.yaml](templates/v2/sections/auth.yaml)
+
+## Operation Limits
+
+| Aspect | v1 (early) | v1 (1.17+) / v2 |
+|--------|-----------|------------------|
+| Config key | `preview_operation_limits` | `limits` |
+
+Both v1.17+ and v2 use `limits`. Only very old v1 installs use `preview_operation_limits`.
+
+## Connectors (Router v2 only)
+
+Connectors are a Router v2 feature. The relevant schema difference is early v2 preview vs current v2 GA:
+
+| Aspect | v2.0.x (preview) | v2.1+ (GA) |
+|--------|-------------------|------------|
+| Config key | `preview_connectors` | `connectors` |
+| Subgraph/source mapping | `subgraphs.<name>.sources.<source>` | `sources.<subgraph>.<source>` (dot notation) |
+
+Only relevant if using Apollo Connectors for REST API integration.
+
+## Telemetry
+
+| Aspect | v1 | v2 |
+|--------|----|----|
+| `experimental_when_header` | Supported | Removed — use custom telemetry events |
+| Metric names | Legacy names | OpenTelemetry naming conventions |
+| Apollo reporting | FTV1 by default | OTLP by default (`otlp_tracing_sampler` defaults to 1.0) |
+| Prometheus exporter | `telemetry.exporters.metrics.prometheus` | Same path |
+
+Telemetry templates are largely compatible. v2 uses OTLP-first reporting.
+
+## Traffic Shaping
+
+Schema is identical between v1 and v2. Behavioral change: v2 returns **HTTP 429**
+for rate-limited requests (restored in v2.1.0 after briefly returning 503 in v2.0.0).
+
+## Context Keys (Coprocessors)
+
+Multiple context keys were renamed in v2. Only relevant if configuring coprocessors.
+
+| v1 Key | v2 Key |
+|--------|--------|
+| `apollo_authentication::JWT::claims` | `apollo::authentication::jwt_claims` |
+| `apollo_operation_id` | `apollo::operation_id` |
+
+> [!TIP]
+> If using coprocessors during migration, set `context: deprecated` to preserve
+> v1 key names while transitioning.
+
+## Key Documentation References
+
+| Topic | URL |
+|-------|-----|
+| v2 YAML Reference | https://www.apollographql.com/docs/graphos/routing/configuration/yaml |
+| v1 → v2 Upgrade Guide | https://www.apollographql.com/docs/graphos/routing/upgrade/from-router-v1 |
+| What's New in v2 | https://www.apollographql.com/docs/graphos/routing/about-v2 |
+| CORS (v2) | https://www.apollographql.com/docs/graphos/routing/security/cors |
+| JWT Auth | https://www.apollographql.com/docs/graphos/routing/security/jwt |
+| Request Limits | https://www.apollographql.com/docs/graphos/routing/security/request-limits |
+| Traffic Shaping | https://www.apollographql.com/docs/graphos/routing/performance/traffic-shaping |
+| v1 EOL Announcement | https://www.apollographql.com/blog/end-of-support-for-router-v1-x-long-term-support-lts-policy-update |

--- a/skills/apollo-router/references/configuration.md
+++ b/skills/apollo-router/references/configuration.md
@@ -1,0 +1,301 @@
+# Router Configuration Reference
+
+The Router is configured via a YAML file (`router.yaml`). This reference covers the most common configuration options.
+
+## Basic Structure
+
+```yaml
+supergraph:
+  listen: 127.0.0.1:4000
+  introspection: true
+  path: /graphql
+
+sandbox:
+  enabled: true
+
+cors:
+  origins:
+    - "*"
+
+headers:
+  all:
+    request:
+      - propagate:
+          matching: ".*"
+
+telemetry:
+  # ... telemetry config
+```
+
+## Supergraph Configuration
+
+```yaml
+supergraph:
+  # Address to listen on
+  listen: 127.0.0.1:4000
+
+  # GraphQL endpoint path
+  path: /graphql
+
+  # Enable introspection queries
+  introspection: true
+
+  # Query planning options
+  query_planning:
+    # Enable query plan caching
+    cache:
+      in_memory:
+        limit: 512
+```
+
+## Sandbox and Introspection
+
+```yaml
+# Apollo Sandbox (GraphQL IDE)
+sandbox:
+  enabled: true  # Disabled by default in production
+
+# Introspection (required for Sandbox)
+supergraph:
+  introspection: true  # Disabled by default in production
+```
+
+For development mode, both are enabled automatically with `--dev`.
+
+## CORS Configuration
+
+```yaml
+cors:
+  # Allowed origins
+  origins:
+    - http://localhost:3000
+    - https://studio.apollographql.com
+
+  # Allow all origins (not recommended for production)
+  # origins:
+  #   - "*"
+
+  # Allowed headers
+  allow_headers:
+    - Content-Type
+    - Authorization
+    - X-Custom-Header
+
+  # Allowed methods (defaults are usually fine)
+  methods:
+    - GET
+    - POST
+    - OPTIONS
+
+  # Allow credentials
+  allow_credentials: true
+
+  # Max age for preflight cache (seconds)
+  max_age: 86400
+```
+
+## Subgraph Configuration
+
+```yaml
+# Override subgraph URLs (useful for local development)
+override_subgraph_url:
+  products: http://localhost:4001/graphql
+  reviews: http://localhost:4002/graphql
+
+# Subgraph-specific settings
+traffic_shaping:
+  all:
+    timeout: 30s
+  subgraphs:
+    products:
+      timeout: 60s  # Override for slow subgraph
+```
+
+## Traffic Shaping
+
+```yaml
+traffic_shaping:
+  # Apply to all subgraphs
+  all:
+    # Request timeout
+    timeout: 30s
+
+    # Rate limiting
+    global_rate_limit:
+      capacity: 1000
+      interval: 1s
+
+  # Router-level settings
+  router:
+    timeout: 60s
+
+  # Per-subgraph settings
+  subgraphs:
+    slow-service:
+      timeout: 120s
+```
+
+## Authentication (JWT)
+
+```yaml
+authentication:
+  router:
+    jwt:
+      jwks:
+        - url: https://auth.example.com/.well-known/jwks.json
+          issuer: https://auth.example.com/
+
+authorization:
+  require_authentication: false  # true = require JWT for all requests
+```
+
+## Response Caching
+
+```yaml
+# In-memory response caching
+supergraph:
+  cache:
+    in_memory:
+      limit: 100MB
+
+# Redis-backed caching
+supergraph:
+  cache:
+    redis:
+      urls:
+        - redis://localhost:6379
+      ttl: 300s
+```
+
+## Persisted Queries (APQ)
+
+```yaml
+apq:
+  enabled: true
+  router:
+    cache:
+      in_memory:
+        limit: 512
+      # Or Redis
+      # redis:
+      #   urls:
+      #     - redis://localhost:6379
+```
+
+## Limits and Security
+
+```yaml
+limits:
+  # Maximum request body size
+  http_max_request_bytes: 2000000  # 2MB
+
+  # Query complexity limits
+  max_depth: 15
+  max_height: 200
+  max_aliases: 30
+  max_root_fields: 20
+```
+
+## Include Subgraph Errors
+
+```yaml
+# Control which subgraph errors are exposed to clients
+include_subgraph_errors:
+  all: true  # Include all subgraph errors (development)
+
+  # Or selectively
+  # all: false
+  # subgraphs:
+  #   products: true  # Only expose products errors
+```
+
+## Subscriptions
+
+```yaml
+subscription:
+  enabled: true
+  mode:
+    # WebSocket-based subscriptions
+    passthrough:
+      all:
+        path: /ws
+
+    # Or callback-based
+    # callback:
+    #   public_url: https://router.example.com/callback
+```
+
+## Development vs Production
+
+### Development Configuration
+
+```yaml
+# router.dev.yaml
+supergraph:
+  introspection: true
+
+sandbox:
+  enabled: true
+
+include_subgraph_errors:
+  all: true
+
+telemetry:
+  exporters:
+    logging:
+      stdout:
+        enabled: true
+        format: text
+```
+
+### Production Configuration
+
+```yaml
+# router.prod.yaml
+supergraph:
+  listen: 0.0.0.0:4000
+  introspection: false
+
+sandbox:
+  enabled: false
+
+include_subgraph_errors:
+  all: false
+
+cors:
+  origins:
+    - https://app.example.com
+
+telemetry:
+  exporters:
+    tracing:
+      otlp:
+        enabled: true
+        endpoint: http://collector:4317
+```
+
+## Environment Variable Expansion
+
+Use environment variables in configuration:
+
+```yaml
+supergraph:
+  listen: ${ROUTER_LISTEN_ADDRESS:-127.0.0.1:4000}
+
+override_subgraph_url:
+  products: ${PRODUCTS_URL}
+
+authentication:
+  router:
+    jwt:
+      jwks:
+        - url: ${JWKS_URL}
+```
+
+## Configuration Validation
+
+Validate configuration without starting the Router:
+
+```bash
+router config validate --config router.yaml
+```

--- a/skills/apollo-router/references/configuration.md
+++ b/skills/apollo-router/references/configuration.md
@@ -280,16 +280,16 @@ Use environment variables in configuration:
 
 ```yaml
 supergraph:
-  listen: ${ROUTER_LISTEN_ADDRESS:-127.0.0.1:4000}
+  listen: ${env.ROUTER_LISTEN_ADDRESS:-127.0.0.1:4000}
 
 override_subgraph_url:
-  products: ${PRODUCTS_URL}
+  products: ${env.PRODUCTS_URL}
 
 authentication:
   router:
     jwt:
       jwks:
-        - url: ${JWKS_URL}
+        - url: ${env.JWKS_URL}
 ```
 
 ## Configuration Validation

--- a/skills/apollo-router/references/connectors.md
+++ b/skills/apollo-router/references/connectors.md
@@ -1,0 +1,41 @@
+# Router Connectors Configuration (v2)
+
+Apollo Connectors are configured in Router v2 under the `connectors` key.
+
+## Core Rules
+
+- Use `connectors` (GA), not `preview_connectors` (early v2 preview).
+- Source keys use `<subgraph>.<source>` naming.
+- `<source>` must match the `@source(name: "...")` used in your connector schema.
+
+## Minimal Router v2 Example
+
+```yaml
+connectors:
+  sources:
+    my_subgraph.my_api:
+      $config:
+        api_version: "v2"
+        feature_flag: true
+```
+
+Use `${env.VAR}` for sensitive values instead of hardcoding secrets in `$config`.
+
+## Migration Note
+
+If you have early v2 preview config:
+
+- Rename `preview_connectors` -> `connectors`
+- Move source mapping from `subgraphs.<name>.sources.<source>` to `sources.<subgraph>.<source>`
+
+## Parameter Checklist
+
+- Subgraph name (for example: `products`)
+- Source name (for example: `inventory`)
+- `$config` keys used by your schema (for example: `api_version`)
+
+## Validate
+
+```bash
+router config validate router.yaml
+```

--- a/skills/apollo-router/references/headers.md
+++ b/skills/apollo-router/references/headers.md
@@ -1,0 +1,269 @@
+# Header Configuration
+
+Configure how the Router handles HTTP headers for requests to subgraphs and responses to clients.
+
+## Header Propagation
+
+Pass headers from client requests to subgraph requests.
+
+### Propagate All Headers
+
+```yaml
+headers:
+  all:
+    request:
+      - propagate:
+          matching: ".*"  # Regex pattern
+```
+
+### Propagate Specific Headers
+
+```yaml
+headers:
+  all:
+    request:
+      # Propagate by exact name
+      - propagate:
+          named: Authorization
+
+      # Propagate by pattern
+      - propagate:
+          matching: "^x-.*"  # All x-* headers
+
+      # Rename while propagating
+      - propagate:
+          named: Authorization
+          rename: X-Auth-Token
+```
+
+### Per-Subgraph Headers
+
+```yaml
+headers:
+  # Default for all subgraphs
+  all:
+    request:
+      - propagate:
+          named: Authorization
+
+  # Override for specific subgraph
+  subgraphs:
+    products:
+      request:
+        - propagate:
+            named: Authorization
+        - propagate:
+            named: X-Products-Key
+```
+
+## Inserting Headers
+
+Add static or dynamic headers to subgraph requests.
+
+### Static Headers
+
+```yaml
+headers:
+  all:
+    request:
+      - insert:
+          name: X-Router-Version
+          value: "1.0"
+
+      - insert:
+          name: X-Api-Key
+          value: ${env.API_KEY}  # From environment
+```
+
+### Dynamic Headers from Context
+
+```yaml
+headers:
+  all:
+    request:
+      # Insert from request context
+      - insert:
+          name: X-Request-Id
+          from_context: request_id
+
+      # Insert from response context (for response headers)
+      - insert:
+          name: X-Trace-Id
+          from_context: apollo_telemetry::trace_id
+```
+
+## Removing Headers
+
+Remove headers before sending to subgraphs or clients.
+
+```yaml
+headers:
+  all:
+    request:
+      # Remove specific header
+      - remove:
+          named: Cookie
+
+      # Remove by pattern
+      - remove:
+          matching: "^x-internal-.*"
+```
+
+## Response Headers
+
+Configure headers sent back to clients.
+
+```yaml
+headers:
+  all:
+    # Response headers to clients
+    response:
+      # Propagate from subgraph response
+      - propagate:
+          named: X-Cache-Status
+
+      # Insert static header
+      - insert:
+          name: X-Powered-By
+          value: "Apollo Router"
+
+      # Remove sensitive headers
+      - remove:
+          named: X-Internal-Debug
+```
+
+## Default Headers
+
+Headers sent to subgraphs by default:
+
+| Header | Description |
+|--------|-------------|
+| `Content-Type` | `application/json` |
+| `Accept` | `application/json` |
+| `apollographql-client-name` | Client name (if provided) |
+| `apollographql-client-version` | Client version (if provided) |
+
+## Complete Example
+
+```yaml
+headers:
+  all:
+    request:
+      # Propagate auth
+      - propagate:
+          named: Authorization
+
+      # Propagate custom headers
+      - propagate:
+          matching: "^x-custom-.*"
+
+      # Add router metadata
+      - insert:
+          name: X-Router-Request-Id
+          from_context: request_id
+
+      # Remove cookies (not needed by subgraphs)
+      - remove:
+          named: Cookie
+
+    response:
+      # Add cache headers
+      - insert:
+          name: Cache-Control
+          value: "private, max-age=60"
+
+      # Propagate trace ID
+      - propagate:
+          named: X-Trace-Id
+
+  subgraphs:
+    products:
+      request:
+        # Additional header for products
+        - insert:
+            name: X-Products-Version
+            value: "v2"
+
+    legacy-service:
+      request:
+        # Rename header for legacy service
+        - propagate:
+            named: Authorization
+            rename: X-Legacy-Auth
+```
+
+## Header Order
+
+Operations execute in order. Later operations can override earlier ones:
+
+```yaml
+headers:
+  all:
+    request:
+      # First: propagate all
+      - propagate:
+          matching: ".*"
+      # Then: remove sensitive ones
+      - remove:
+          matching: "^x-internal-.*"
+      # Finally: add new ones
+      - insert:
+          name: X-Router
+          value: "true"
+```
+
+## Environment Variable Expansion
+
+```yaml
+headers:
+  all:
+    request:
+      - insert:
+          name: X-Api-Key
+          value: ${env.API_KEY}
+
+      - insert:
+          name: X-Environment
+          value: ${env.ENVIRONMENT:-development}  # With default
+```
+
+## Common Patterns
+
+### Authentication Propagation
+
+```yaml
+headers:
+  all:
+    request:
+      - propagate:
+          named: Authorization
+      - propagate:
+          named: Cookie
+```
+
+### Request Tracing
+
+```yaml
+headers:
+  all:
+    request:
+      - propagate:
+          named: X-Request-Id
+      - propagate:
+          named: X-Correlation-Id
+      - insert:
+          name: X-Router-Trace
+          from_context: apollo_telemetry::trace_id
+```
+
+### Multi-Tenant Headers
+
+```yaml
+headers:
+  all:
+    request:
+      - propagate:
+          named: X-Tenant-Id
+      - propagate:
+          named: X-Organization-Id
+```

--- a/skills/apollo-router/references/plugins.md
+++ b/skills/apollo-router/references/plugins.md
@@ -1,0 +1,280 @@
+# Router Customization
+
+Extend Apollo Router functionality with Rhai scripts or external coprocessors.
+
+## Customization Options
+
+| Option | Language | Use Case |
+|--------|----------|----------|
+| **Rhai Scripts** | Rhai (embedded) | Simple transformations, header manipulation |
+| **Coprocessors** | Any (HTTP service) | Complex logic, external service calls |
+| **Native Plugins** | Rust | Maximum performance, deep integration |
+
+## Rhai Scripts
+
+Rhai is an embedded scripting language for lightweight customizations that run inside the Router.
+
+### Enable Rhai
+
+```yaml
+# router.yaml
+rhai:
+  scripts: ./rhai
+  main: main.rhai
+```
+
+### Script Location
+
+```
+project/
+├── router.yaml
+└── rhai/
+    ├── main.rhai        # Entry point
+    └── helpers.rhai     # Optional modules
+```
+
+### Basic Script Structure
+
+```rhai
+// main.rhai
+
+// Called for each incoming request
+fn supergraph_service(service) {
+    service.map_request(|request| {
+        // Modify request
+        print(`Received request: ${request.uri.path}`);
+    });
+}
+
+// Called for each subgraph request
+fn subgraph_service(service, subgraph) {
+    service.map_request(|request| {
+        // Add header for specific subgraph
+        if subgraph == "products" {
+            request.subgraph.headers["x-products-version"] = "v2";
+        }
+    });
+}
+```
+
+### Common Rhai Patterns
+
+**Add Request Headers:**
+```rhai
+fn supergraph_service(service) {
+    service.map_request(|request| {
+        request.headers["x-custom-header"] = "value";
+    });
+}
+```
+
+**Access JWT Claims:**
+```rhai
+fn supergraph_service(service) {
+    service.map_request(|request| {
+        let claims = request.context["apollo_authentication::JWT::claims"];
+        if claims != () {
+            request.headers["x-user-id"] = claims["sub"];
+        }
+    });
+}
+```
+
+**Modify Response:**
+```rhai
+fn supergraph_service(service) {
+    service.map_response(|response| {
+        response.headers["x-served-by"] = "apollo-router";
+    });
+}
+```
+
+**Early Return (Reject Request):**
+```rhai
+fn supergraph_service(service) {
+    service.map_request(|request| {
+        if request.headers["x-api-key"] == () {
+            throw #{
+                status: 401,
+                message: "API key required"
+            };
+        }
+    });
+}
+```
+
+### Rhai Hooks
+
+| Hook | Description |
+|------|-------------|
+| `supergraph_service` | Entry point for all requests |
+| `execution_service` | After query planning |
+| `subgraph_service` | Before each subgraph request |
+
+## Coprocessors
+
+External HTTP services that process requests/responses at various stages.
+
+### Enable Coprocessor
+
+```yaml
+# router.yaml
+coprocessor:
+  url: http://localhost:8080
+  timeout: 2s
+  router:
+    request:
+      headers: true
+      body: true
+    response:
+      headers: true
+      body: true
+```
+
+### Coprocessor Stages
+
+```yaml
+coprocessor:
+  url: http://localhost:8080
+  
+  # Router-level (full request)
+  router:
+    request:
+      headers: true
+      body: true
+    response:
+      headers: true
+      body: false
+  
+  # Subgraph-level (per subgraph)
+  subgraph:
+    all:
+      request:
+        headers: true
+        body: false
+```
+
+### Coprocessor Request Format
+
+The Router sends POST requests with this structure:
+
+```json
+{
+  "version": 1,
+  "stage": "RouterRequest",
+  "control": "continue",
+  "id": "request-uuid",
+  "headers": {
+    "authorization": ["Bearer token"],
+    "content-type": ["application/json"]
+  },
+  "body": "{\"query\": \"{ users { id } }\"}"
+}
+```
+
+### Coprocessor Response Format
+
+Return JSON to modify the request/response:
+
+```json
+{
+  "version": 1,
+  "stage": "RouterRequest",
+  "control": "continue",
+  "headers": {
+    "x-user-id": ["123"]
+  }
+}
+```
+
+To reject a request:
+
+```json
+{
+  "version": 1,
+  "stage": "RouterRequest",
+  "control": {
+    "break": 403
+  },
+  "body": "{\"errors\": [{\"message\": \"Forbidden\"}]}"
+}
+```
+
+### Example Coprocessor (Node.js)
+
+```javascript
+const express = require('express');
+const app = express();
+app.use(express.json());
+
+app.post('/', (req, res) => {
+  const { stage, headers, body } = req.body;
+  
+  // Authentication check
+  if (stage === 'RouterRequest') {
+    if (!headers.authorization) {
+      return res.json({
+        version: 1,
+        stage,
+        control: { break: 401 },
+        body: JSON.stringify({
+          errors: [{ message: 'Unauthorized' }]
+        })
+      });
+    }
+  }
+  
+  // Continue with optional modifications
+  res.json({
+    version: 1,
+    stage,
+    control: 'continue',
+    headers: {
+      'x-processed-by': ['coprocessor']
+    }
+  });
+});
+
+app.listen(8080);
+```
+
+## Choosing Between Rhai and Coprocessors
+
+| Criteria | Rhai | Coprocessor |
+|----------|------|-------------|
+| Latency | ~1-5ms | ~10-50ms (network) |
+| Language | Rhai only | Any language |
+| Complexity | Simple logic | Complex business logic |
+| External calls | Not supported | Supported |
+| Deployment | Bundled with Router | Separate service |
+
+### When to Use Rhai
+
+- Header manipulation
+- Simple request/response transformations
+- Logging and debugging
+- Context value extraction
+
+### When to Use Coprocessors
+
+- External API calls (validation, enrichment)
+- Complex business logic
+- Database lookups
+- Integration with existing services
+- Team uses a specific language
+
+## Native Plugins (Advanced)
+
+For maximum performance, build custom Router binaries with Rust plugins.
+
+```bash
+# Clone Router
+git clone https://github.com/apollographql/router.git
+
+# Create custom plugin in apollo-router/src/plugins/
+
+# Build with custom plugins
+cargo build --release
+```
+
+Native plugins require Rust knowledge and a custom build pipeline.

--- a/skills/apollo-router/references/telemetry.md
+++ b/skills/apollo-router/references/telemetry.md
@@ -238,7 +238,7 @@ telemetry:
 
 ## GraphOS Studio
 
-Send telemetry to Apollo Studio:
+Send telemetry to GraphOS Studio:
 
 ```yaml
 telemetry:

--- a/skills/apollo-router/references/telemetry.md
+++ b/skills/apollo-router/references/telemetry.md
@@ -1,0 +1,323 @@
+# Router Telemetry
+
+Configure logging, metrics, and tracing with OpenTelemetry-compatible exporters.
+
+## Telemetry Overview
+
+The Router supports three types of telemetry:
+
+| Type | Description | Exporters |
+|------|-------------|-----------|
+| **Logs** | Structured event logging | stdout, file |
+| **Metrics** | Numerical measurements | Prometheus, OTLP, Datadog |
+| **Traces** | Distributed request tracing | Jaeger, Zipkin, OTLP, Datadog |
+
+## Basic Configuration
+
+```yaml
+telemetry:
+  exporters:
+    logging:
+      stdout:
+        enabled: true
+        format: json
+
+    metrics:
+      prometheus:
+        enabled: true
+        listen: 127.0.0.1:9090
+        path: /metrics
+
+    tracing:
+      otlp:
+        enabled: true
+        endpoint: http://collector:4317
+```
+
+## Logging
+
+### Stdout Logging
+
+```yaml
+telemetry:
+  exporters:
+    logging:
+      stdout:
+        enabled: true
+        format: json  # or "text" for human-readable
+```
+
+### Log Level
+
+Set via environment variable:
+```bash
+APOLLO_ROUTER_LOG=debug router
+```
+
+Or in configuration:
+```yaml
+telemetry:
+  exporters:
+    logging:
+      stdout:
+        enabled: true
+      common:
+        service_name: my-router
+```
+
+Log levels: `off`, `error`, `warn`, `info`, `debug`, `trace`
+
+## Metrics
+
+### Prometheus
+
+```yaml
+telemetry:
+  exporters:
+    metrics:
+      prometheus:
+        enabled: true
+        listen: 127.0.0.1:9090
+        path: /metrics
+```
+
+Access metrics at `http://localhost:9090/metrics`.
+
+Common metrics:
+- `apollo_router_http_requests_total` - Request count
+- `apollo_router_http_request_duration_seconds` - Latency histogram
+- `apollo_router_cache_hit_count` - Cache hit/miss
+
+### OTLP Metrics
+
+```yaml
+telemetry:
+  exporters:
+    metrics:
+      otlp:
+        enabled: true
+        endpoint: http://collector:4317
+        protocol: grpc  # or "http"
+```
+
+### Datadog Metrics
+
+```yaml
+telemetry:
+  exporters:
+    metrics:
+      datadog:
+        enabled: true
+        endpoint: https://api.datadoghq.com
+```
+
+Set `DD_API_KEY` environment variable.
+
+## Tracing
+
+### OTLP (OpenTelemetry)
+
+```yaml
+telemetry:
+  exporters:
+    tracing:
+      otlp:
+        enabled: true
+        endpoint: http://collector:4317
+        protocol: grpc
+
+      common:
+        service_name: apollo-router
+```
+
+### Jaeger
+
+```yaml
+telemetry:
+  exporters:
+    tracing:
+      jaeger:
+        enabled: true
+        agent:
+          endpoint: localhost:6831
+```
+
+Or via collector:
+```yaml
+telemetry:
+  exporters:
+    tracing:
+      jaeger:
+        enabled: true
+        collector:
+          endpoint: http://jaeger:14268/api/traces
+```
+
+### Zipkin
+
+```yaml
+telemetry:
+  exporters:
+    tracing:
+      zipkin:
+        enabled: true
+        endpoint: http://zipkin:9411/api/v2/spans
+```
+
+### Datadog
+
+```yaml
+telemetry:
+  exporters:
+    tracing:
+      datadog:
+        enabled: true
+        endpoint: http://localhost:8126
+```
+
+## Sampling
+
+Control trace sampling rate:
+
+```yaml
+telemetry:
+  exporters:
+    tracing:
+      common:
+        sampler: 0.5  # Sample 50% of requests
+
+      # Or always sample
+      # sampler: always_on
+
+      # Or never sample
+      # sampler: always_off
+```
+
+## Custom Attributes
+
+Add custom attributes to spans:
+
+```yaml
+telemetry:
+  instrumentation:
+    spans:
+      router:
+        attributes:
+          # Static attribute
+          environment:
+            static_value: production
+
+          # From request header
+          client_id:
+            request_header: x-client-id
+
+          # From response header
+          cache_status:
+            response_header: x-cache-status
+```
+
+## Trace Context Propagation
+
+```yaml
+telemetry:
+  exporters:
+    tracing:
+      propagation:
+        # W3C Trace Context (default)
+        trace_context: true
+
+        # Jaeger propagation
+        jaeger: true
+
+        # Zipkin B3
+        zipkin: true
+
+        # Datadog
+        datadog: true
+```
+
+## GraphOS Studio
+
+Send telemetry to Apollo Studio:
+
+```yaml
+telemetry:
+  apollo:
+    client_name_header: apollographql-client-name
+    client_version_header: apollographql-client-version
+```
+
+Requires `APOLLO_KEY` and `APOLLO_GRAPH_REF` environment variables.
+
+## Complete Example
+
+```yaml
+telemetry:
+  apollo:
+    client_name_header: apollographql-client-name
+    client_version_header: apollographql-client-version
+
+  exporters:
+    logging:
+      stdout:
+        enabled: true
+        format: json
+
+    metrics:
+      prometheus:
+        enabled: true
+        listen: 0.0.0.0:9090
+        path: /metrics
+
+    tracing:
+      otlp:
+        enabled: true
+        endpoint: http://otel-collector:4317
+        protocol: grpc
+
+      common:
+        service_name: apollo-router
+        sampler: 0.1  # 10% sampling
+
+      propagation:
+        trace_context: true
+
+  instrumentation:
+    spans:
+      router:
+        attributes:
+          environment:
+            static_value: ${env.ENVIRONMENT:-development}
+          client:
+            request_header: x-client-id
+```
+
+## Docker Compose Example
+
+```yaml
+version: "3.8"
+services:
+  router:
+    image: ghcr.io/apollographql/router:latest
+    ports:
+      - "4000:4000"
+      - "9090:9090"
+    environment:
+      - APOLLO_ROUTER_LOG=info
+    volumes:
+      - ./router.yaml:/etc/router/router.yaml
+      - ./supergraph.graphql:/etc/router/supergraph.graphql
+
+  prometheus:
+    image: prom/prometheus
+    ports:
+      - "9091:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+
+  jaeger:
+    image: jaegertracing/all-in-one
+    ports:
+      - "16686:16686"
+      - "6831:6831/udp"
+```

--- a/skills/apollo-router/references/troubleshooting.md
+++ b/skills/apollo-router/references/troubleshooting.md
@@ -1,0 +1,294 @@
+# Router Troubleshooting
+
+Common issues and solutions when running Apollo Router.
+
+## Startup Issues
+
+### Router Fails to Start
+
+**Error: No supergraph schema provided**
+
+```
+Error: No supergraph schema found. Provide --supergraph or set APOLLO_GRAPH_REF.
+```
+
+Fix: Provide a supergraph schema:
+```bash
+# Local file
+router --supergraph ./supergraph.graphql
+
+# Or GraphOS managed
+export APOLLO_KEY=service:my-graph:key
+export APOLLO_GRAPH_REF=my-graph@production
+router
+```
+
+**Error: Invalid configuration**
+
+```
+Error: configuration error: unknown field `cors`
+```
+
+Fix: Check YAML syntax and field names:
+```bash
+# Validate config
+router config validate --config router.yaml
+```
+
+### Port Already in Use
+
+```
+Error: Address already in use (os error 48)
+```
+
+Fix: Use a different port or stop the existing process:
+```bash
+# Check what's using the port
+lsof -i :4000
+
+# Use different port
+router --supergraph ./supergraph.graphql --listen 127.0.0.1:4001
+```
+
+## Connection Issues
+
+### Cannot Connect to Subgraphs
+
+**Error: Connection refused**
+
+```
+Error: error sending request for url (http://localhost:4001/graphql): error trying to connect
+```
+
+Checklist:
+1. Verify subgraph is running: `curl http://localhost:4001/graphql`
+2. Check URL in supergraph schema is correct
+3. For Docker, use host.docker.internal or service names
+
+Override subgraph URL for local development:
+```yaml
+# router.yaml
+override_subgraph_url:
+  products: http://host.docker.internal:4001/graphql
+```
+
+**Error: Timeout**
+
+```
+Error: operation timed out
+```
+
+Increase timeout:
+```yaml
+traffic_shaping:
+  subgraphs:
+    slow-service:
+      timeout: 60s
+```
+
+### GraphOS Connection Issues
+
+**Error: Failed to fetch schema from Uplink**
+
+```
+Error: failed to fetch schema: Uplink request failed
+```
+
+Checklist:
+1. Verify `APOLLO_KEY` is correct
+2. Verify `APOLLO_GRAPH_REF` format: `graph-id@variant`
+3. Check network connectivity to Apollo
+
+```bash
+# Test connection
+curl -H "X-Api-Key: $APOLLO_KEY" \
+  https://uplink.api.apollographql.com/
+```
+
+## Query Issues
+
+### Introspection Not Working
+
+**Error: Introspection disabled**
+
+```json
+{
+  "errors": [{ "message": "Introspection has been disabled" }]
+}
+```
+
+Fix: Enable introspection (development only):
+```yaml
+supergraph:
+  introspection: true
+```
+
+Or use `--dev` mode:
+```bash
+router --dev --supergraph ./supergraph.graphql
+```
+
+### Sandbox Not Loading
+
+Sandbox requires introspection. Enable both:
+```yaml
+supergraph:
+  introspection: true
+
+sandbox:
+  enabled: true
+```
+
+Or use `--dev` mode which enables both.
+
+### CORS Errors
+
+**Error: Browser blocked by CORS policy**
+
+```
+Access to fetch has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header
+```
+
+Fix: Configure CORS:
+```yaml
+cors:
+  origins:
+    - http://localhost:3000
+    - https://studio.apollographql.com
+  allow_headers:
+    - Content-Type
+    - Authorization
+```
+
+For development (not production):
+```yaml
+cors:
+  origins:
+    - "*"
+```
+
+## Performance Issues
+
+### Slow Queries
+
+Debug steps:
+
+1. **Enable query plan logs:**
+```yaml
+telemetry:
+  exporters:
+    logging:
+      stdout:
+        enabled: true
+        format: json
+```
+
+2. **Check subgraph latency:**
+Enable tracing to identify slow subgraphs.
+
+3. **Enable caching:**
+```yaml
+supergraph:
+  query_planning:
+    cache:
+      in_memory:
+        limit: 512
+```
+
+### High Memory Usage
+
+1. **Limit cache sizes:**
+```yaml
+supergraph:
+  query_planning:
+    cache:
+      in_memory:
+        limit: 256  # Reduce from default
+```
+
+2. **Check for complex queries** that generate large query plans.
+
+## Federation Issues
+
+### Composition Errors at Runtime
+
+Router logs composition errors:
+```
+Error: Subgraph schema validation failed
+```
+
+Fix: Validate schema before deploying:
+```bash
+rover subgraph check my-graph@production \
+  --name products \
+  --schema ./schema.graphql
+```
+
+### Entity Resolution Failures
+
+**Error: Cannot resolve entity**
+
+```json
+{
+  "errors": [{ "message": "cannot resolve entity of type User" }]
+}
+```
+
+Checklist:
+1. Subgraph implements `_entities` query
+2. Entity's `@key` fields match between subgraphs
+3. Reference resolver returns correct data format
+
+## Health Check
+
+Check Router health:
+```bash
+curl http://localhost:4000/.well-known/apollo/server-health
+```
+
+Expected response:
+```json
+{"status":"healthy"}
+```
+
+For Kubernetes readiness probe:
+```yaml
+readinessProbe:
+  httpGet:
+    path: /.well-known/apollo/server-health
+    port: 4000
+  initialDelaySeconds: 5
+  periodSeconds: 10
+```
+
+## Debug Mode
+
+Get more verbose output:
+```bash
+APOLLO_ROUTER_LOG=debug router --supergraph ./supergraph.graphql
+```
+
+Log levels:
+- `error` - Errors only
+- `warn` - Warnings and errors
+- `info` - General information (default)
+- `debug` - Detailed debug information
+- `trace` - Very verbose tracing
+
+## Common Mistakes
+
+| Mistake | Solution |
+|---------|----------|
+| Introspection disabled in dev | Use `--dev` flag |
+| Wrong subgraph URL in production | Use `override_subgraph_url` |
+| CORS not configured | Add allowed origins |
+| Timeout too short | Increase `traffic_shaping.timeout` |
+| Missing APOLLO_KEY | Set environment variable |
+| Wrong graph ref format | Use `graph-id@variant` |
+
+## Getting Help
+
+1. Check [Router documentation](https://www.apollographql.com/docs/router/)
+2. Search [Apollo Community](https://community.apollographql.com/)
+3. Check [GitHub Issues](https://github.com/apollographql/router/issues)
+4. Enable debug logging for detailed error information

--- a/skills/apollo-router/references/troubleshooting.md
+++ b/skills/apollo-router/references/troubleshooting.md
@@ -61,7 +61,7 @@ Error: error sending request for url (http://localhost:4001/graphql): error tryi
 ```
 
 Checklist:
-1. Verify subgraph is running: `curl http://localhost:4001/graphql`
+1. Verify subgraph is running: `curl -X POST http://localhost:4001/graphql -H "Content-Type: application/json" -d '{"query":"{ __typename }"}'`
 2. Check URL in supergraph schema is correct
 3. For Docker, use host.docker.internal or service names
 

--- a/skills/apollo-router/templates/v1/development.yaml
+++ b/skills/apollo-router/templates/v1/development.yaml
@@ -1,0 +1,51 @@
+# ═══════════════════════════════════════════════════════════════
+# Apollo Router Core — Development Configuration (v1.x)
+# NOTE: Use `router --dev` to auto-enable introspection + sandbox.
+#   This file is for explicit dev configuration without --dev flag.
+# ═══════════════════════════════════════════════════════════════
+
+supergraph:
+  listen: 127.0.0.1:4000
+  path: /graphql
+  introspection: true
+
+sandbox:
+  enabled: true
+
+homepage:
+  enabled: true
+
+health_check:
+  enabled: true
+  listen: 127.0.0.1:8088
+  path: /health
+
+include_subgraph_errors:
+  all: true
+
+# ── CORS (v1 flat schema — permissive for development) ─────────
+cors:
+  origins:
+    - "*"
+  allow_headers:
+    - Content-Type
+    - Authorization
+  methods:
+    - GET
+    - POST
+    - OPTIONS
+
+# ── Header Propagation ─────────────────────────────────────────
+headers:
+  all:
+    request:
+      - propagate:
+          matching: ".*"
+
+# ── Telemetry (human-readable logs, no exporters) ──────────────
+telemetry:
+  exporters:
+    logging:
+      stdout:
+        enabled: true
+        format: text

--- a/skills/apollo-router/templates/v1/production.yaml
+++ b/skills/apollo-router/templates/v1/production.yaml
@@ -1,0 +1,129 @@
+# ═══════════════════════════════════════════════════════════════
+# Apollo Router Core — Production Configuration (v1.x)
+# Generated for Router v1.17+ (operation limits GA)
+# NOTE: v1.x has reached end-of-support. Migrate to v2.x.
+#   Run: router config upgrade router.yaml
+# ═══════════════════════════════════════════════════════════════
+
+supergraph:
+  listen: 0.0.0.0:4000
+  path: /graphql
+  introspection: false
+  query_planning:
+    cache:
+      in_memory:
+        limit: 512
+
+sandbox:
+  enabled: false
+
+homepage:
+  enabled: false
+
+health_check:
+  enabled: true
+  listen: 0.0.0.0:8088
+  path: /health
+
+include_subgraph_errors:
+  all: false
+
+# ── CORS (v1 flat schema) ──────────────────────────────────────
+cors:
+  origins:
+    - https://app.example.com
+    - https://studio.apollographql.com
+  allow_headers:
+    - Content-Type
+    - Authorization
+  methods:
+    - GET
+    - POST
+    - OPTIONS
+  allow_credentials: true
+  max_age: 24h
+
+# ── Authentication (v1: issuer is singular string) ─────────────
+authentication:
+  router:
+    jwt:
+      jwks:
+        - url: ${env.JWKS_URL}
+          issuer: ${env.JWT_ISSUER}
+
+authorization:
+  require_authentication: true
+
+# ── Operation Limits (v1.17+ uses `limits`, not `preview_operation_limits`) ──
+# Tip: Start with warn_only: true to observe real traffic, then enforce.
+# Router default for max_depth is 100; 50 is a balanced starting point.
+limits:
+  http_max_request_bytes: 2000000
+  max_depth: 50
+  max_height: 200
+  max_aliases: 30
+  max_root_fields: 20
+  # warn_only: true  # Uncomment during initial rollout to log without rejecting
+
+# ── Traffic Shaping ────────────────────────────────────────────
+traffic_shaping:
+  router:
+    timeout: 60s
+    global_rate_limit:
+      capacity: 1000
+      interval: 1s
+  all:
+    timeout: 30s
+
+# ── Header Propagation ─────────────────────────────────────────
+headers:
+  all:
+    request:
+      - propagate:
+          matching: "^(authorization|x-.*)$"
+
+# ── APQ ────────────────────────────────────────────────────────
+apq:
+  enabled: true
+  router:
+    cache:
+      in_memory:
+        limit: 512
+
+# ── Telemetry ──────────────────────────────────────────────────
+telemetry:
+  apollo:
+    client_name_header: apollographql-client-name
+    client_version_header: apollographql-client-version
+
+  exporters:
+    logging:
+      stdout:
+        enabled: true
+        format: json
+
+    metrics:
+      prometheus:
+        enabled: true
+        listen: 0.0.0.0:9090
+        path: /metrics
+
+    tracing:
+      otlp:
+        enabled: true
+        endpoint: ${env.OTEL_COLLECTOR_ENDPOINT:-http://otel-collector:4317}
+        protocol: grpc
+      common:
+        service_name: apollo-router
+        sampler: 0.1
+      propagation:
+        trace_context: true
+
+  instrumentation:
+    spans:
+      router:
+        attributes:
+          environment:
+            static_value: ${env.ENVIRONMENT:-production}
+          client:
+            request_header: x-client-id

--- a/skills/apollo-router/templates/v1/sections/auth.yaml
+++ b/skills/apollo-router/templates/v1/sections/auth.yaml
@@ -1,0 +1,10 @@
+# JWT Authentication — v1 (issuer is a singular string)
+authentication:
+  router:
+    jwt:
+      jwks:
+        - url: ${env.JWKS_URL}
+          issuer: ${env.JWT_ISSUER}
+
+authorization:
+  require_authentication: true

--- a/skills/apollo-router/templates/v1/sections/cors.yaml
+++ b/skills/apollo-router/templates/v1/sections/cors.yaml
@@ -1,0 +1,14 @@
+# CORS — v1 flat schema
+cors:
+  origins:
+    - https://app.example.com
+    - https://studio.apollographql.com
+  allow_headers:
+    - Content-Type
+    - Authorization
+  methods:
+    - GET
+    - POST
+    - OPTIONS
+  allow_credentials: true
+  max_age: 24h

--- a/skills/apollo-router/templates/v1/sections/headers.yaml
+++ b/skills/apollo-router/templates/v1/sections/headers.yaml
@@ -1,0 +1,6 @@
+# Header Propagation (v1 and v2 — identical schema)
+headers:
+  all:
+    request:
+      - propagate:
+          matching: "^(authorization|x-.*)$"

--- a/skills/apollo-router/templates/v1/sections/limits.yaml
+++ b/skills/apollo-router/templates/v1/sections/limits.yaml
@@ -1,0 +1,11 @@
+# Operation Limits (v1.17+ and v2 — identical schema)
+# Tip: Start with warn_only: true to observe real traffic, then enforce.
+# Router default for max_depth is 100; 50 is a balanced starting point.
+# For v1 < 1.17, use `preview_operation_limits` instead of `limits`.
+limits:
+  http_max_request_bytes: 2000000
+  max_depth: 50
+  max_height: 200
+  max_aliases: 30
+  max_root_fields: 20
+  # warn_only: true  # Uncomment during initial rollout to log without rejecting

--- a/skills/apollo-router/templates/v1/sections/telemetry.yaml
+++ b/skills/apollo-router/templates/v1/sections/telemetry.yaml
@@ -1,0 +1,39 @@
+# Telemetry — v1
+# v1 uses FTV1 reporting by default to GraphOS Studio.
+# OTLP tracing is available but not the default reporting format.
+telemetry:
+  apollo:
+    client_name_header: apollographql-client-name
+    client_version_header: apollographql-client-version
+
+  exporters:
+    logging:
+      stdout:
+        enabled: true
+        format: json
+
+    metrics:
+      prometheus:
+        enabled: true
+        listen: 0.0.0.0:9090
+        path: /metrics
+
+    tracing:
+      otlp:
+        enabled: true
+        endpoint: ${env.OTEL_COLLECTOR_ENDPOINT:-http://otel-collector:4317}
+        protocol: grpc
+      common:
+        service_name: apollo-router
+        sampler: 0.1
+      propagation:
+        trace_context: true
+
+  instrumentation:
+    spans:
+      router:
+        attributes:
+          environment:
+            static_value: ${env.ENVIRONMENT:-production}
+          client:
+            request_header: x-client-id

--- a/skills/apollo-router/templates/v1/sections/traffic-shaping.yaml
+++ b/skills/apollo-router/templates/v1/sections/traffic-shaping.yaml
@@ -1,0 +1,12 @@
+# Traffic Shaping (v1 and v2 — identical schema)
+# NOTE: global_rate_limit under `router:` limits CLIENT requests.
+#       Under `all:` it limits SUBGRAPH requests from the router.
+# v2 returns HTTP 429 for rate-limited requests (v2.1.0+).
+traffic_shaping:
+  router:
+    timeout: 60s
+    global_rate_limit:
+      capacity: 1000
+      interval: 1s
+  all:
+    timeout: 30s

--- a/skills/apollo-router/templates/v2/development.yaml
+++ b/skills/apollo-router/templates/v2/development.yaml
@@ -1,0 +1,51 @@
+# ═══════════════════════════════════════════════════════════════
+# Apollo GraphOS Router — Development Configuration (v2.x)
+# NOTE: Use `router --dev` to auto-enable introspection + sandbox.
+#   This file is for explicit dev configuration without --dev flag.
+# ═══════════════════════════════════════════════════════════════
+
+supergraph:
+  listen: 127.0.0.1:4000
+  path: /graphql
+  introspection: true
+
+sandbox:
+  enabled: true
+
+homepage:
+  enabled: false
+
+health_check:
+  enabled: true
+  listen: 127.0.0.1:8088
+  path: /health
+
+include_subgraph_errors:
+  all: true
+
+# ── CORS (v2 wildcard dev mode) ─────────────────────────────────
+cors:
+  allow_any_origin: true
+  methods:
+    - GET
+    - POST
+    - OPTIONS
+  max_age: 24h
+  allow_headers:
+    - Content-Type
+    - Authorization
+
+# ── Header Propagation ─────────────────────────────────────────
+headers:
+  all:
+    request:
+      - propagate:
+          matching: ".*"
+
+# ── Telemetry (human-readable logs, no exporters) ──────────────
+telemetry:
+  exporters:
+    logging:
+      stdout:
+        enabled: true
+        format: text

--- a/skills/apollo-router/templates/v2/production.yaml
+++ b/skills/apollo-router/templates/v2/production.yaml
@@ -1,0 +1,131 @@
+# ═══════════════════════════════════════════════════════════════
+# Apollo GraphOS Router — Production Configuration (v2.x)
+# Generated for Router v2.10+ / Federation v2.12+
+# ═══════════════════════════════════════════════════════════════
+
+supergraph:
+  listen: 0.0.0.0:4000
+  path: /graphql
+  introspection: false
+  query_planning:
+    cache:
+      in_memory:
+        limit: 512
+
+sandbox:
+  enabled: false
+
+homepage:
+  enabled: false
+
+health_check:
+  enabled: true
+  listen: 0.0.0.0:8088
+  path: /health
+
+include_subgraph_errors:
+  all: false
+
+# ── CORS (v2 policies schema) ──────────────────────────────────
+cors:
+  allow_credentials: true
+  methods:
+    - GET
+    - POST
+    - OPTIONS
+  max_age: 24h
+  policies:
+    - origins:
+        - https://app.example.com
+        - https://studio.apollographql.com
+      allow_headers:
+        - Content-Type
+        - Authorization
+
+# ── Authentication (v2: issuers is plural, array) ──────────────
+authentication:
+  router:
+    jwt:
+      jwks:
+        - url: ${env.JWKS_URL}
+          issuers:
+            - ${env.JWT_ISSUER}
+
+authorization:
+  require_authentication: true
+
+# ── Operation Limits ───────────────────────────────────────────
+# Tip: Start with warn_only: true to observe real traffic, then enforce.
+# Router default for max_depth is 100; 50 is a balanced starting point.
+limits:
+  http_max_request_bytes: 2000000
+  max_depth: 50
+  max_height: 200
+  max_aliases: 30
+  max_root_fields: 20
+  # warn_only: true  # Uncomment during initial rollout to log without rejecting
+
+# ── Traffic Shaping ────────────────────────────────────────────
+# NOTE: global_rate_limit under `router:` limits CLIENT requests.
+#       Under `all:` it limits SUBGRAPH requests from the router.
+traffic_shaping:
+  router:
+    timeout: 60s
+    global_rate_limit:
+      capacity: 1000
+      interval: 1s
+  all:
+    timeout: 30s
+
+# ── Header Propagation ─────────────────────────────────────────
+headers:
+  all:
+    request:
+      - propagate:
+          matching: "^(authorization|x-.*)$"
+
+# ── APQ ────────────────────────────────────────────────────────
+apq:
+  enabled: true
+  router:
+    cache:
+      in_memory:
+        limit: 512
+
+# ── Telemetry ──────────────────────────────────────────────────
+telemetry:
+  apollo:
+    client_name_header: apollographql-client-name
+    client_version_header: apollographql-client-version
+
+  exporters:
+    logging:
+      stdout:
+        enabled: true
+        format: json
+
+    metrics:
+      prometheus:
+        enabled: true
+        listen: 0.0.0.0:9090
+        path: /metrics
+
+    tracing:
+      otlp:
+        enabled: true
+        endpoint: ${env.OTEL_COLLECTOR_ENDPOINT:-http://otel-collector:4317}
+        protocol: grpc
+      common:
+        service_name: apollo-router
+        sampler: 0.1
+      propagation:
+        trace_context: true
+
+  instrumentation:
+    spans:
+      router:
+        attributes:
+          environment:
+            static_value: ${env.ENVIRONMENT:-production}
+          client:
+            request_header: x-client-id

--- a/skills/apollo-router/templates/v2/sections/auth.yaml
+++ b/skills/apollo-router/templates/v2/sections/auth.yaml
@@ -1,0 +1,13 @@
+# JWT Authentication — v2 (issuers is plural, array)
+# BREAKING CHANGE from v1: `issuer` (string) → `issuers` (array).
+# `issuer` is v1-only; use `issuers` in v2.
+authentication:
+  router:
+    jwt:
+      jwks:
+        - url: ${env.JWKS_URL}
+          issuers:
+            - ${env.JWT_ISSUER}
+
+authorization:
+  require_authentication: true

--- a/skills/apollo-router/templates/v2/sections/connectors.yaml
+++ b/skills/apollo-router/templates/v2/sections/connectors.yaml
@@ -1,0 +1,10 @@
+# Connectors — v2 (GA)
+# Use `connectors` for current Router v2.
+# Early v2 preview used `preview_connectors`.
+# Key format is `<subgraph>.<source>`.
+connectors:
+  sources:
+    my_subgraph.my_api:
+      $config:
+        api_version: "v2"
+        feature_flag: true

--- a/skills/apollo-router/templates/v2/sections/cors.yaml
+++ b/skills/apollo-router/templates/v2/sections/cors.yaml
@@ -1,0 +1,17 @@
+# CORS — v2 policies schema
+# v2 uses a policies array instead of flat origins.
+# max_age uses duration strings (e.g., 24h) not integers.
+cors:
+  allow_credentials: true
+  methods:
+    - GET
+    - POST
+    - OPTIONS
+  max_age: 24h
+  policies:
+    - origins:
+        - https://app.example.com
+        - https://studio.apollographql.com
+      allow_headers:
+        - Content-Type
+        - Authorization

--- a/skills/apollo-router/templates/v2/sections/headers.yaml
+++ b/skills/apollo-router/templates/v2/sections/headers.yaml
@@ -1,0 +1,6 @@
+# Header Propagation (v2 — identical schema to v1)
+headers:
+  all:
+    request:
+      - propagate:
+          matching: "^(authorization|x-.*)$"

--- a/skills/apollo-router/templates/v2/sections/limits.yaml
+++ b/skills/apollo-router/templates/v2/sections/limits.yaml
@@ -1,0 +1,10 @@
+# Operation Limits (v2 — same schema as v1.17+)
+# Tip: Start with warn_only: true to observe real traffic, then enforce.
+# Router default for max_depth is 100; 50 is a balanced starting point.
+limits:
+  http_max_request_bytes: 2000000
+  max_depth: 50
+  max_height: 200
+  max_aliases: 30
+  max_root_fields: 20
+  # warn_only: true  # Uncomment during initial rollout to log without rejecting

--- a/skills/apollo-router/templates/v2/sections/telemetry.yaml
+++ b/skills/apollo-router/templates/v2/sections/telemetry.yaml
@@ -1,0 +1,40 @@
+# Telemetry — v2
+# v2 uses OTLP-first reporting to GraphOS Studio (otlp_tracing_sampler defaults to 1.0).
+# Legacy FTV1 reporting is still available but secondary.
+# `experimental_when_header` is removed in v2 — use custom telemetry events instead.
+telemetry:
+  apollo:
+    client_name_header: apollographql-client-name
+    client_version_header: apollographql-client-version
+
+  exporters:
+    logging:
+      stdout:
+        enabled: true
+        format: json
+
+    metrics:
+      prometheus:
+        enabled: true
+        listen: 0.0.0.0:9090
+        path: /metrics
+
+    tracing:
+      otlp:
+        enabled: true
+        endpoint: ${env.OTEL_COLLECTOR_ENDPOINT:-http://otel-collector:4317}
+        protocol: grpc
+      common:
+        service_name: apollo-router
+        sampler: 0.1
+      propagation:
+        trace_context: true
+
+  instrumentation:
+    spans:
+      router:
+        attributes:
+          environment:
+            static_value: ${env.ENVIRONMENT:-production}
+          client:
+            request_header: x-client-id

--- a/skills/apollo-router/templates/v2/sections/traffic-shaping.yaml
+++ b/skills/apollo-router/templates/v2/sections/traffic-shaping.yaml
@@ -1,0 +1,12 @@
+# Traffic Shaping (v2 — identical schema to v1)
+# NOTE: global_rate_limit under `router:` limits CLIENT requests.
+#       Under `all:` it limits SUBGRAPH requests from the router.
+# v2 returns HTTP 429 for rate-limited requests (v2.1.0+).
+traffic_shaping:
+  router:
+    timeout: 60s
+    global_rate_limit:
+      capacity: 1000
+      interval: 1s
+  all:
+    timeout: 30s

--- a/skills/apollo-router/validation/checklist.md
+++ b/skills/apollo-router/validation/checklist.md
@@ -1,0 +1,52 @@
+# Post-Generation Validation Checklist
+
+Run through this checklist after generating a `router.yaml` to catch common mistakes.
+
+## Security
+
+- [ ] **Introspection disabled** (production): `supergraph.introspection: false`
+- [ ] **Sandbox disabled** (production): `sandbox.enabled: false`
+- [ ] **Homepage disabled** (production): `homepage.enabled: false`
+- [ ] **Subgraph errors hidden** (production): `include_subgraph_errors.all: false`
+- [ ] **No wildcard CORS** (production): explicit origins only (no `"*"` and no `allow_any_origin: true`)
+- [ ] **Authentication required** (if applicable): `authorization.require_authentication: true`
+
+## Version Correctness
+
+- [ ] **CORS schema matches version**:
+  - v1: flat `cors.origins: [...]`
+  - v2: `cors.policies: [{ origins: [...] }]`
+- [ ] **JWT issuer field matches version**:
+  - v1: `issuer: <string>` (singular)
+  - v2: `issuers: [<string>]` (plural array)
+- [ ] **Max age format matches version**:
+  - v1: duration string (`max_age: 24h`)
+  - v2: duration string (`max_age: 24h`)
+- [ ] **Limits key is correct**: Use `limits` (v1.17+ and v2), not `preview_operation_limits`
+- [ ] **Connectors key is correct** (if applicable): early v2 preview = `preview_connectors`, current v2 GA = `connectors`
+
+## Operational
+
+- [ ] **Health check enabled**: `health_check.enabled: true` with a listen address
+- [ ] **Rate limiting on `router:`**: `traffic_shaping.router.global_rate_limit` limits client requests; `all:` limits subgraph requests
+- [ ] **All env vars documented**: Every `${env.VAR}` in the config has a corresponding entry in deployment docs
+- [ ] **APOLLO_KEY not hardcoded**: API key is via environment variable, never in config file or logs
+- [ ] **Secrets use env var expansion**: `${env.JWKS_URL}`, `${env.JWT_ISSUER}`, etc.
+
+## Telemetry
+
+- [ ] **Logging format is JSON** (production): `telemetry.exporters.logging.stdout.format: json`
+- [ ] **Tracing sampler is set**: `sampler: 0.1` (10%) is a reasonable default; tune for your traffic volume
+- [ ] **Service name is set**: `common.service_name` identifies this router instance
+
+## Recommended Final Step
+
+```bash
+# Validate config syntax against the Router's schema
+router config validate router.yaml
+```
+
+If migrating from v1 to v2, use the built-in upgrade tool:
+```bash
+router config upgrade router.yaml
+```


### PR DESCRIPTION
## Summary

Adds a new `apollo-router` skill to configure and run federated graphs.

## Changes

- Add `skills/apollo-router/SKILL.md` with quick start, configuration overview, and ground rules
- Add reference files:
  - `configuration.md` yaml config (supergraph, CORS, traffic shaping, auth, caching)
  - `headers.md` header propagation insertion and removal
  - `plugins.md` Rhai scripts and coprocessors
  - `telemetry.md` Logging metrics and tracing exporters
  - `troubleshooting.md`
- Update `README.md`

## Use cases

This skill activates when users are:
- Setting up Apollo Router for a supergraph
- Configuring routing, headers, or CORS
- Implementing Rhai scripts or coprocessors
- Configuring telemetry (tracing, metrics, logging)
- Troubleshooting Router issues