### PR TITLE
Standardize skill version format

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+* @apollographql/ai-apps
+/skills/apollo-client/ @apollographql/client-typescript
+

--- a/skills/apollo-client/SKILL.md
+++ b/skills/apollo-client/SKILL.md
@@ -11,7 +11,7 @@ license: MIT
 compatibility: React 18+, React 19 (Suspense/RSC). Works with Next.js, Vite, CRA, and other React frameworks.
 metadata:
   author: apollographql
-  version: "1.0"
+  version: "1.0.0"
 allowed-tools: Bash(npm:*) Bash(npx:*) Bash(node:*) Read Write Edit Glob Grep
 ---
 

--- a/skills/apollo-connectors/SKILL.md
+++ b/skills/apollo-connectors/SKILL.md
@@ -11,7 +11,7 @@ license: MIT
 compatibility: Requires rover CLI installed. Works with Claude Code and similar AI coding assistants.
 metadata:
   author: apollographql
-  version: "1.0"
+  version: "1.0.0"
 allowed-tools: Bash(rover:*) Bash(curl:*) Read Write Edit Glob Grep
 ---
 

--- a/skills/apollo-server/SKILL.md
+++ b/skills/apollo-server/SKILL.md
@@ -11,7 +11,7 @@ license: MIT
 compatibility: Node.js v20+, TypeScript 4.7+. Works with Express v4/v5, standalone, Fastify, and serverless.
 metadata:
   author: apollographql
-  version: "1.0"
+  version: "1.0.0"
 allowed-tools: Bash(npm:*) Bash(npx:*) Bash(node:*) Read Write Edit Glob Grep
 ---
 

--- a/skills/graphql-operations/SKILL.md
+++ b/skills/graphql-operations/SKILL.md
@@ -11,7 +11,7 @@ license: MIT
 compatibility: Any GraphQL client (Apollo Client, urql, Relay, etc.)
 metadata:
   author: apollographql
-  version: "1.0"
+  version: "1.0.0"
 allowed-tools: Bash(npm:*) Bash(npx:*) Read Write Edit Glob Grep
 ---
 

--- a/skills/graphql-schema/SKILL.md
+++ b/skills/graphql-schema/SKILL.md
@@ -11,7 +11,7 @@ license: MIT
 compatibility: Any GraphQL implementation (Apollo Server, graphql-js, Yoga, etc.)
 metadata:
   author: apollographql
-  version: "1.0"
+  version: "1.0.0"
 allowed-tools: Bash(npm:*) Bash(npx:*) Read Write Edit Glob Grep
 ---
 

--- a/skills/rover/SKILL.md
+++ b/skills/rover/SKILL.md
@@ -11,7 +11,7 @@ license: MIT
 compatibility: Node.js v18+, Linux/macOS/Windows
 metadata:
   author: apollographql
-  version: "1.0"
+  version: "1.0.0"
 allowed-tools: Bash(rover:*) Bash(curl:*) Bash(npm:*) Bash(npx:*) Read Write Edit Glob Grep
 ---
 

--- a/skills/rust-best-practices/SKILL.md
+++ b/skills/rust-best-practices/SKILL.md
@@ -12,7 +12,7 @@ license: MIT
 compatibility: Rust 1.70+, Cargo
 metadata:
   author: apollographql
-  version: "1.1"
+  version: "1.1.0"
 allowed-tools: Bash(cargo:*) Bash(rustc:*) Bash(rustfmt:*) Bash(clippy:*) Read Write Edit Glob Grep
 ---
 

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -227,6 +227,22 @@ For Apollo GraphQL-specific guidance:
 
 - [Apollo Skills](references/apollo-skills.md) - Patterns and examples for Apollo GraphQL skills
 
+## Versioning
+
+Use semantic versioning (`"X.Y.Z"`) for the `version` field in metadata:
+
+```yaml
+metadata:
+  author: apollographql
+  version: "1.0.0"
+```
+
+- **Major (X)**: Breaking changes that alter how the skill behaves or activates (e.g., renamed triggers, removed sections, changed ground rules)
+- **Minor (Y)**: New content or capabilities that are backward-compatible (e.g., added reference files, new sections, expanded examples)
+- **Patch (Z)**: Small fixes that don't change behavior (e.g., typo corrections, wording tweaks, formatting fixes)
+
+Start new skills at `"1.0.0"`.
+
 ## Checklist for New Skills
 
 Before publishing a skill, verify:

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -10,7 +10,7 @@ license: MIT
 compatibility: Works with Claude Code and similar AI coding assistants that support Agent Skills.
 metadata:
   author: apollographql
-  version: "1.0"
+  version: "1.0.0"
 allowed-tools: Read Write Edit Glob Grep
 ---
 
@@ -48,7 +48,7 @@ license: MIT
 compatibility: Works with Claude Code and similar AI coding assistants.
 metadata:
   author: your-org
-  version: "1.0"
+  version: "1.0.0"
 allowed-tools: Read Write Edit Glob Grep
 ---
 ```


### PR DESCRIPTION
All skills now use a consistent three-segment "X.Y.Z" version format in their SKILL.md front matter. Previously, some skills used "X.Y" while others already used "X.Y.Z", making the format inconsistent across the repo. Also added a Versioning section to the skill-creator skill so that future skills follow the same convention.