### PR TITLE
Add Claude Code Plugin support

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "apollo-graphql",
+  "owner": {
+    "name": "Apollo GraphQL"
+  },
+  "metadata": {
+    "description": "Skills for AI coding agents working with Apollo GraphQL tools and technologies",
+    "version": "1.0.0"
+  },
+  "plugins": [
+    {
+      "name": "apollo-graphql",
+      "source": ".",
+      "description": "Apollo GraphQL development skills covering Client, Server, Connectors, Kotlin, Rover, MCP Server, schema design, operations, and Rust best practices",
+      "version": "1.0.0",
+      "license": "MIT",
+      "keywords": ["graphql", "apollo", "apollo-client", "apollo-server", "apollo-connectors", "rover"]
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "apollo-graphql",
+  "description": "Apollo GraphQL development skills for Claude Code",
+  "version": "1.0.0",
+  "author": {
+    "name": "Apollo GraphQL",
+    "email": "opensource@apollographql.com"
+  },
+  "homepage": "https://github.com/apollographql/skills",
+  "repository": "https://github.com/apollographql/skills",
+  "license": "MIT",
+  "keywords": ["graphql", "apollo"]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,45 @@ jobs:
           done
           echo "✅ All skills successfully installed"
 
+  validate-plugin:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Validate marketplace.json
+        run: jq empty .claude-plugin/marketplace.json
+
+      - name: Validate plugin.json
+        run: jq empty .claude-plugin/plugin.json
+
+      - name: Cross-check plugin names
+        run: |
+          marketplace_name=$(jq -r '.plugins[0].name' .claude-plugin/marketplace.json)
+          plugin_name=$(jq -r '.name' .claude-plugin/plugin.json)
+          if [ "$marketplace_name" != "$plugin_name" ]; then
+            echo "❌ Name mismatch: marketplace.json has '$marketplace_name', plugin.json has '$plugin_name'"
+            exit 1
+          fi
+          echo "✅ Plugin name '$plugin_name' matches across manifests"
+
+      - name: Verify all skills are discoverable
+        run: |
+          echo "Checking that all skills have SKILL.md files..."
+          count=0
+          for skill in skills/*/; do
+            skill_name=$(basename "$skill")
+            if [ -f "$skill/SKILL.md" ]; then
+              echo "✅ Found $skill_name/SKILL.md"
+              count=$((count + 1))
+            else
+              echo "❌ $skill_name/SKILL.md not found"
+              exit 1
+            fi
+          done
+          echo "✅ All $count skills discoverable by Claude Code plugin"
+
   test-remote:
     runs-on: ubuntu-latest
     # Run only on push to main

--- a/README.md
+++ b/README.md
@@ -33,6 +33,37 @@ The CLI guides you through an interactive installation:
 └
 ```
 
+## Claude Code Plugin
+
+You can also install skills as a [Claude Code plugin](https://code.claude.com/docs/en/discover-plugins):
+
+First, add the marketplace:
+
+```bash
+/plugin marketplace add apollographql/skills
+```
+
+Then, install the plugin:
+
+```bash
+/plugin install apollo-graphql@apollo-graphql
+```
+
+Once installed, skills are available as namespaced slash commands:
+
+| Slash Command | Description |
+|---|---|
+| `/apollo-graphql:apollo-client` | Apollo Client 4.x for React — queries, mutations, caching, local state |
+| `/apollo-graphql:apollo-connectors` | Apollo Connectors — integrate REST APIs into GraphQL |
+| `/apollo-graphql:apollo-kotlin` | Apollo Kotlin — GraphQL client for Android and Kotlin |
+| `/apollo-graphql:apollo-mcp-server` | Apollo MCP Server — connect AI agents with GraphQL APIs |
+| `/apollo-graphql:apollo-server` | Apollo Server 4.x — schemas, resolvers, auth, plugins |
+| `/apollo-graphql:graphql-operations` | GraphQL operations — queries, mutations, fragments |
+| `/apollo-graphql:graphql-schema` | GraphQL schema design — types, naming, pagination, errors |
+| `/apollo-graphql:rover` | Rover CLI — schema management and local supergraph development |
+| `/apollo-graphql:rust-best-practices` | Rust best practices — idiomatic Rust following Apollo conventions |
+| `/apollo-graphql:skill-creator` | Skill creator — guide for creating new Apollo skills |
+
 ## Available Skills
 
 ### apollo-connectors
@@ -463,7 +494,7 @@ You can also explicitly invoke a skill depending on your tool:
 
 | Tool           | Automatic | Explicit Invocation                                     |
 | -------------- | --------- | ------------------------------------------------------- |
-| Claude Code    | Yes       | Slash command (e.g., `/graphql-schema`)                 |
+| Claude Code    | Yes       | Slash command (e.g., `/graphql-schema` or `/apollo-graphql:graphql-schema` via plugin) |
 | GitHub Copilot | Yes       | `/agent` for custom agents, `@github` for GitHub skills |
 | Cursor         | Yes       | Rules matched by file patterns (no direct invocation)   |
 | Windsurf       | Yes       | Slash command for workflows (e.g., `/workflow-name`)    |


### PR DESCRIPTION
Add manifest files so Apollo Skills can also be installed through the Claude Code plugin marketplace. A `.claude-plugin/` directory is added with marketplace.json and plugin.json. The existing `skills/*/SKILL.md` structure is reused as-is, so no SKILL.md changes are needed.