### PR TITLE
Fix incorrect field names in apollo-mcp-server skill config examples

### DIFF
--- a/skills/apollo-mcp-server/SKILL.md
+++ b/skills/apollo-mcp-server/SKILL.md
@@ -10,7 +10,7 @@ license: MIT
 compatibility: Works with Claude Code, Claude Desktop, Cursor.
 metadata:
   author: apollographql
-  version: "1.0.1"
+  version: "1.0.2"
 allowed-tools: Bash(rover:*) Bash(curl:*) Bash(npx:*) Read Write Edit Glob Grep
 ---
 
@@ -44,7 +44,7 @@ schema:
 operations:
   source: local
   paths:
-    - ./operations/**/*.graphql
+    - ./operations/
 introspection:
   introspect:
     enabled: true
@@ -105,7 +105,7 @@ MCP tools are created from GraphQL operations. Three methods:
 operations:
   source: local
   paths:
-    - ./operations/**/*.graphql
+    - ./operations/
 ```
 
 ```graphql
@@ -214,8 +214,8 @@ overrides:
 schema:
   source: uplink
 graphos:
-  key: ${APOLLO_KEY}
-  graph_ref: my-graph@production
+  apollo_key: ${APOLLO_KEY}
+  apollo_graph_ref: my-graph@production
 ```
 
 ### Local Development

--- a/skills/apollo-mcp-server/references/configuration.md
+++ b/skills/apollo-mcp-server/references/configuration.md
@@ -71,8 +71,8 @@ schema:
 schema:
   source: uplink
 graphos:
-  key: ${APOLLO_KEY}
-  graph_ref: my-graph@production
+  apollo_key: ${APOLLO_KEY}
+  apollo_graph_ref: my-graph@production
 ```
 
 #### Introspection
@@ -253,8 +253,8 @@ Connect to Apollo GraphOS for managed schemas and operations.
 
 ```yaml
 graphos:
-  key: ${APOLLO_KEY}
-  graph_ref: my-graph@production
+  apollo_key: ${APOLLO_KEY}
+  apollo_graph_ref: my-graph@production
 ```
 
 ### Environment Variables
@@ -270,8 +270,8 @@ export APOLLO_GRAPH_REF=my-graph@production
 schema:
   source: uplink
 graphos:
-  key: ${APOLLO_KEY}
-  graph_ref: ${APOLLO_GRAPH_REF}
+  apollo_key: ${APOLLO_KEY}
+  apollo_graph_ref: ${APOLLO_GRAPH_REF}
 ```
 
 ---
@@ -351,7 +351,7 @@ All settings support environment variable substitution with `${VAR_NAME}`.
 | Variable | Description |
 |----------|-------------|
 | `APOLLO_KEY` | GraphOS API key |
-| `APOLLO_GRAPH_REF` | Graph reference (graph-id@variant) |
+| `APOLLO_GRAPH_REF` | Graph reference (graph@variant) |
 
 ---
 
@@ -386,8 +386,8 @@ operations:
   source: manifest
   path: ./persisted-query-manifest.json
 graphos:
-  key: ${APOLLO_KEY}
-  graph_ref: ${APOLLO_GRAPH_REF}
+  apollo_key: ${APOLLO_KEY}
+  apollo_graph_ref: ${APOLLO_GRAPH_REF}
 headers:
   Authorization: "Bearer ${API_TOKEN}"
 introspection:

--- a/skills/apollo-mcp-server/references/troubleshooting.md
+++ b/skills/apollo-mcp-server/references/troubleshooting.md
@@ -24,8 +24,13 @@ npx @modelcontextprotocol/inspector
 ### Usage
 
 ```bash
-# Start inspector with your MCP server
+# Start inspector with your MCP server using the STDIO transport
 npx @modelcontextprotocol/inspector .apollo-mcp-server ./config.yaml
+```
+
+```bash
+# Start inspector with your MCP server using the StreamableHttp transport
+npx @modelcontextprotocol/inspector --transport http --server-url http://localhost:8000/mcp
 ```
 
 ### Inspector Features
@@ -197,7 +202,7 @@ echo $APOLLO_GRAPH_REF
 2. Check graph reference format:
 ```yaml
 graphos:
-  graph_ref: my-graph@production  # Format: graph-id@variant
+  apollo_graph_ref: my-graph@production  # Format: graph@variant
 ```
 
 ---

--- a/skills/rover/SKILL.md
+++ b/skills/rover/SKILL.md
@@ -11,7 +11,7 @@ license: MIT
 compatibility: Node.js v18+, Linux/macOS/Windows
 metadata:
   author: apollographql
-  version: "1.0.0"
+  version: "1.0.1"
 allowed-tools: Bash(rover:*) Bash(curl:*) Bash(npm:*) Bash(npx:*) Read Write Edit Glob Grep
 ---
 
@@ -216,7 +216,7 @@ rover subgraph fetch my-graph@production --name products --format plain
 ## Ground Rules
 
 - ALWAYS authenticate before using GraphOS commands (`rover config auth` or `APOLLO_KEY`)
-- ALWAYS use the correct graph reference format: `graph-id@variant`
+- ALWAYS use the correct graph reference format: `graph@variant`
 - PREFER `rover subgraph check` before `rover subgraph publish` in CI/CD
 - USE `rover dev` for local supergraph development instead of running Router manually
 - NEVER commit `APOLLO_KEY` to version control; use environment variables


### PR DESCRIPTION
The YAML snippets under the `graphos` key were using `key` and `graph_ref`, but the actual Apollo MCP Server configuration expects `apollo_key` and `apollo_graph_ref`. This updates all six occurrences across SKILL.md, references/configuration.md, and references/troubleshooting.md to match the official documentation.