### PR TITLE
Remove curl from allowed tools

### DIFF
--- a/skills/apollo-connectors/SKILL.md
+++ b/skills/apollo-connectors/SKILL.md
@@ -12,7 +12,7 @@ compatibility: Requires rover CLI installed. Works with Claude Code and similar 
 metadata:
   author: apollographql
   version: "1.0.0"
-allowed-tools: Bash(rover:*) Bash(curl:*) Read Write Edit Glob Grep
+allowed-tools: Bash(rover:*) Read Write Edit Glob Grep
 ---
 
 # Apollo Connectors Schema Assistant

--- a/skills/apollo-mcp-server/SKILL.md
+++ b/skills/apollo-mcp-server/SKILL.md
@@ -11,7 +11,7 @@ compatibility: Works with Claude Code, Claude Desktop, Cursor.
 metadata:
   author: apollographql
   version: "1.0.2"
-allowed-tools: Bash(rover:*) Bash(curl:*) Bash(npx:*) Read Write Edit Glob Grep
+allowed-tools: Bash(rover:*) Bash(npx:*) Read Write Edit Glob Grep
 ---
 
 # Apollo MCP Server Guide

--- a/skills/rover/SKILL.md
+++ b/skills/rover/SKILL.md
@@ -12,7 +12,7 @@ compatibility: Node.js v18+, Linux/macOS/Windows
 metadata:
   author: apollographql
   version: "1.0.1"
-allowed-tools: Bash(rover:*) Bash(curl:*) Bash(npm:*) Bash(npx:*) Read Write Edit Glob Grep
+allowed-tools: Bash(rover:*) Bash(npm:*) Bash(npx:*) Read Write Edit Glob Grep
 ---
 
 # Apollo Rover CLI Guide

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -62,7 +62,7 @@ allowed-tools: Read Write Edit Glob Grep
 | `license` | No | License name (e.g., MIT, Apache-2.0). |
 | `compatibility` | No | Environment requirements. Max 500 chars. |
 | `metadata` | No | Key-value pairs for author, version, etc. |
-| `allowed-tools` | No | Space-delimited list of pre-approved tools. |
+| `allowed-tools` | No | Space-delimited list of pre-approved tools. Do not include `Bash(curl:*)`. |
 
 ### Name Rules
 
@@ -266,3 +266,4 @@ Before publishing a skill, verify:
 - PREFER specific examples over abstract explanations
 - PREFER opinionated guidance over listing multiple options
 - USE `allowed-tools` to pre-approve tools the skill needs
+- NEVER include `Bash(curl:*)` in `allowed-tools` as it grants unrestricted network access and enables `curl | sh` remote code execution patterns


### PR DESCRIPTION
<!-- https://apollographql.atlassian.net/browse/AMS-418 -->

A security audit identified three skills (`apollo-connectors`, `apollo-mcp-server`, `rover`) that allow unrestricted `curl` access via `Bash(curl:*)` in their `allowed-tools` frontmatter. This permission lets an AI agent make any HTTP requests without user approval, including running the `curl | sh` remote code execution pattern found in the installation instructions for `rover` and `apollo-mcp-server`.

This PR removes `Bash(curl:*)` from all three skills. They will still work fully, but now `curl` commands will need explicit user confirmation before running. This gives users a chance to review network requests.

Also, the `skill-creator` skill has been updated to prevent `Bash(curl:*)` in new skills moving forward, both in the frontmatter documentation and as a clear ground rule.