### PR TITLE
Update apollo-mcp-server skill for accuracy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Install all skills (local)
         run: |
-          npx skills add . --yes
+          npx skills@1.4.0 add . --yes
           echo "✅ Successfully installed all skills locally"
 
       - name: Verify skills installed

--- a/skills/apollo-mcp-server/references/tools.md
+++ b/skills/apollo-mcp-server/references/tools.md
@@ -14,7 +14,9 @@
 
 ## Introspection Tools
 
-Apollo MCP Server provides four built-in tools for schema exploration and operation execution.
+Apollo MCP Server provides four built-in tools for schema exploration and operation execution. All tools are disabled by default and must be enabled in configuration.
+
+Each introspection tool supports an optional `hint` config option for providing custom instructions to the AI agent about when and how to use the tool.
 
 ### introspect
 
@@ -54,7 +56,7 @@ type User {
 
 **Output (minified):**
 ```
-T User { id:ID! name:s! email:s posts:[Post!]! createdAt:DateTime! }
+T User { id:d! name:s! email:s posts:[Post!]! createdAt:DateTime! }
 ```
 
 **Depth Behavior:**
@@ -75,6 +77,13 @@ Find types in the schema matching a query.
 | `query` | String | required | Search term |
 | `leafDepth` | Int | 1 | Depth for leaf type expansion |
 | `minify` | Boolean | false | Use compact notation |
+
+**Config Options:**
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `index_memory_bytes` | `50000000` | Memory budget for the search index |
+| `leaf_depth` | `1` | Default leaf type expansion depth |
 
 **Behavior:**
 
@@ -207,7 +216,7 @@ Compact notation reduces token usage by 40-60%. Enable globally or per-request.
 | `I` | input |
 | `E` | enum |
 | `U` | union |
-| `IF` | interface |
+| `F` | interface |
 
 ### Scalar Abbreviations
 
@@ -217,7 +226,7 @@ Compact notation reduces token usage by 40-60%. Enable globally or per-request.
 | `i` | Int |
 | `f` | Float |
 | `b` | Boolean |
-| `ID` | ID (unchanged) |
+| `d` | ID |
 
 ### Modifiers
 
@@ -228,6 +237,8 @@ Compact notation reduces token usage by 40-60%. Enable globally or per-request.
 | **[!]** | List of non-null |
 | **[]!** | Non-null list |
 | **[!]!** | Non-null list of non-null |
+| `@D` | Deprecated |
+| `<>` | Implements |
 
 ### Examples
 
@@ -245,7 +256,7 @@ type Product {
 
 **Minified:**
 ```
-T Product { id:ID! name:s! price:f! description:s tags:[s!]! variants:[ProductVariant!] }
+T Product { id:d! name:s! price:f! description:s tags:[s!]! variants:[ProductVariant!] }
 ```
 
 ---


### PR DESCRIPTION
<!-- https://apollographql.atlassian.net/browse/AMS-402 -->

### Summary

- Fix inaccuracies found by comparing the skill against the code and docs
- Prioritize `streamable_http` transport over `stdio` across all docs to reflect the MCP ecosystem's shift toward remote servers
- Bump version from `1.0.2` to `1.1.0`

### Changes

**Cross-cutting fixes (all files):**
- Env var syntax: `${VAR}` → `${env.VAR}` (correct YAML config expansion syntax)
- Header forwarding: replaced `from:` nested syntax with top-level `forward_headers: [list]`
- Health check: port `3000` → `8000`, response `{"status": "healthy"}` → `{"status": "UP"}`
- Transport ordering: `streamable_http` presented first, `stdio` second everywhere
- Removed `schema.source: introspect` (not a valid schema source — only `local` and `uplink`)
- Simplified examples by omitting values that match defaults

**`SKILL.md`:**
- Fixed Windows install URL: hard-coded `v1.6.0` → `latest`
- Rewrote Step 2 (Configure) with `streamable_http` transport and default endpoint/port notes
- Rewrote Step 3 (Connect) with streamable HTTP primary (`npx mcp-remote`), stdio secondary
- Added OAuth `transport.auth` example to Authentication section
- Updated minify notation to include `d` = ID
- Added Docker common pattern
- Added ground rules for transport preference

**`references/configuration.md`:**
- Reordered Transport section: streamable HTTP first with defaults table, stdio second
- Added Host Validation, Auth, and Logging sections
- Removed invalid schema sources (`introspect`, `paths` plural)
- Fixed custom scalars to use `custom_scalars: ./file.json` + JSON format
- Fixed CORS field names (`allow_origins`, `allow_credentials`, etc.)
- Fixed telemetry to use `exporters.metrics.otlp` / `exporters.tracing.otlp` structure
- Replaced fabricated env vars (`APOLLO_MCP_CONFIG`, `APOLLO_MCP_LOG_LEVEL`) with `APOLLO_MCP_` + `__` override convention
- Added SSE removal note (v1.5.0)

**`references/tools.md`:**
- Fixed minify abbreviations: `IF` → `F` (interface), `ID` → `d`
- Added `@D` (deprecated) and `<>` (implements) modifiers
- Added `hint` config option note for introspection tools
- Added `search` config options (`index_memory_bytes`, `leaf_depth`)

**`references/troubleshooting.md`:**
- Fixed MCP Inspector command: `.apollo-mcp-server` → `apollo-mcp-server`
- Reordered inspector/client examples: streamable HTTP first
- Fixed debug env var: `APOLLO_MCP_LOG_LEVEL` → `APOLLO_MCP_LOGGING__LEVEL`
- Replaced OAuth `from:` syntax with `transport.auth` and `forward_headers`
- Removed `Schema Introspection Failed` section (no longer a valid schema source)