### PR TITLE
ci: add AI-powered skill sync workflow

### DIFF
--- a/.github/workflows/ai-skill-sync.yml
+++ b/.github/workflows/ai-skill-sync.yml
@@ -1,0 +1,271 @@
+name: AI Skill Sync
+
+on:
+  repository_dispatch:
+    types: [product-update]
+  workflow_dispatch:
+    inputs:
+      product:
+        description: "Skill name (directory under skills/)"
+        required: true
+        type: string
+      repository:
+        description: "Product repository (owner/repo). Defaults to apollographql/{product}."
+        required: false
+        type: string
+      version:
+        description: "Version tag to sync to (leave empty for latest stable)"
+        required: false
+        type: string
+
+concurrency:
+  group: ai-skill-sync-${{ inputs.product || github.event.client_payload.product }}
+  cancel-in-progress: true
+
+jobs:
+  resolve-inputs:
+    runs-on: ubuntu-latest
+    outputs:
+      product: ${{ steps.resolve.outputs.product }}
+      repository: ${{ steps.resolve.outputs.repository }}
+      version: ${{ steps.version.outputs.target }}
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout skills repo
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: skills
+          sparse-checkout-cone-mode: true
+
+      - name: Resolve and validate inputs
+        id: resolve
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            PRODUCT="${{ inputs.product }}"
+            REPO="${{ inputs.repository }}"
+            REPO="${REPO:-apollographql/$PRODUCT}"
+          else
+            PRODUCT="${{ github.event.client_payload.product }}"
+            REPO="${{ github.event.client_payload.repository }}"
+          fi
+
+          if [ ! -d "skills/$PRODUCT" ]; then
+            echo "::error::Skill directory 'skills/$PRODUCT' does not exist"
+            exit 1
+          fi
+
+          echo "product=$PRODUCT" >> "$GITHUB_OUTPUT"
+          echo "repository=$REPO" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout product repo
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ steps.resolve.outputs.repository }}
+          path: product-repo
+          fetch-depth: 0
+          # No ref here — we need all tags for version resolution.
+          # The resolved version is used as ref in downstream jobs.
+
+      - name: Resolve version
+        id: version
+        env:
+          INPUT_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.version || github.event.client_payload.version }}
+        run: |
+          cd product-repo
+          if [ -n "$INPUT_VERSION" ]; then
+            echo "target=$INPUT_VERSION" >> "$GITHUB_OUTPUT"
+          else
+            LATEST=$(git tag --list 'v*' --sort=-version:refname \
+              | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+              | head -1)
+            if [ -z "$LATEST" ]; then
+              echo "::error::No stable version tags found in ${{ steps.resolve.outputs.repository }}"
+              exit 1
+            fi
+            echo "target=$LATEST" >> "$GITHUB_OUTPUT"
+            echo "Auto-detected latest stable version: $LATEST"
+          fi
+
+  triage:
+    needs: resolve-inputs
+    runs-on: ubuntu-latest
+    outputs:
+      needs_update: ${{ steps.parse.outputs.needs_update }}
+      reason: ${{ steps.parse.outputs.reason }}
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout skills repo
+        uses: actions/checkout@v6
+
+      - name: Checkout product repo
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ needs.resolve-inputs.outputs.repository }}
+          ref: ${{ needs.resolve-inputs.outputs.version }}
+          path: product-repo
+          fetch-depth: 0
+
+      - name: Generate diff between releases
+        id: diff
+        env:
+          VERSION: ${{ needs.resolve-inputs.outputs.version }}
+        run: |
+          cd product-repo
+          # Find the previous stable release tag
+          PREV_TAG=$(git tag --list 'v*' --sort=-version:refname \
+            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+            | grep -v "^${VERSION}$" \
+            | head -1) || true
+          if [ -n "$PREV_TAG" ]; then
+            git diff "${PREV_TAG}...${VERSION}" > ../changes.diff
+            echo "prev_tag=$PREV_TAG" >> "$GITHUB_OUTPUT"
+          else
+            # First release — diff entire tree
+            git diff --no-index /dev/null . > ../changes.diff || true
+            echo "prev_tag=" >> "$GITHUB_OUTPUT"
+          fi
+          echo "Diff size: $(wc -c < ../changes.diff) bytes"
+
+      - name: Triage changes
+        id: triage
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            The ${{ needs.resolve-inputs.outputs.product }} product has a new release.
+            Repository: ${{ needs.resolve-inputs.outputs.repository }}
+            Version: ${{ needs.resolve-inputs.outputs.version }}
+            Previous version: ${{ steps.diff.outputs.prev_tag }}
+
+            The full diff between releases is in changes.diff.
+            The product source code is in product-repo/.
+
+            Review the diff against the current skill in
+            skills/${{ needs.resolve-inputs.outputs.product }}/.
+
+            Read all skill files (SKILL.md and everything in references/) to
+            understand what the skill currently documents.
+
+            Determine if the skill needs updating. It DOES need updating if:
+            - An API or config option documented in the skill has changed
+            - A code example in the skill is now incorrect
+            - A recommended pattern has been deprecated or replaced
+            - A breaking change affects the skill's guidance
+
+            It does NOT need updating if:
+            - New features were added that the skill doesn't cover yet
+            - Internal refactoring with no user-facing impact
+            - Minor bug fixes unrelated to skill content
+            - Documentation typo fixes in the product repo
+
+            Respond with exactly one line:
+            NEEDS_UPDATE: <brief reason>
+            or
+            NO_UPDATE_NEEDED: <brief reason>
+          claude_args: "--allowedTools Read,Glob,Grep --max-turns 10"
+
+      - name: Parse triage result
+        id: parse
+        env:
+          TRIAGE_RESULT: ${{ steps.triage.outputs.result }}
+        run: |
+          RESULT="$TRIAGE_RESULT"
+          if echo "$RESULT" | grep -q "^NEEDS_UPDATE:"; then
+            echo "needs_update=true" >> "$GITHUB_OUTPUT"
+            REASON=$(echo "$RESULT" | grep "^NEEDS_UPDATE:" | sed 's/^NEEDS_UPDATE: //')
+            echo "reason=$REASON" >> "$GITHUB_OUTPUT"
+          else
+            echo "needs_update=false" >> "$GITHUB_OUTPUT"
+            REASON=$(echo "$RESULT" | grep "^NO_UPDATE_NEEDED:" | sed 's/^NO_UPDATE_NEEDED: //' || true)
+            echo "reason=$REASON" >> "$GITHUB_OUTPUT"
+          fi
+
+  update-skill:
+    needs: [resolve-inputs, triage]
+    if: needs.triage.outputs.needs_update == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: Checkout skills repo
+        uses: actions/checkout@v6
+
+      - name: Checkout product repo
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ needs.resolve-inputs.outputs.repository }}
+          ref: ${{ needs.resolve-inputs.outputs.version }}
+          path: product-repo
+          fetch-depth: 0
+
+      - name: Generate diff between releases
+        id: diff
+        env:
+          VERSION: ${{ needs.resolve-inputs.outputs.version }}
+        run: |
+          cd product-repo
+          PREV_TAG=$(git tag --list 'v*' --sort=-version:refname \
+            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+            | grep -v "^${VERSION}$" \
+            | head -1) || true
+          if [ -n "$PREV_TAG" ]; then
+            git diff "${PREV_TAG}...${VERSION}" > ../changes.diff
+            echo "prev_tag=$PREV_TAG" >> "$GITHUB_OUTPUT"
+          else
+            git diff --no-index /dev/null . > ../changes.diff || true
+            echo "prev_tag=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Generate skill updates with AI
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            The ${{ needs.resolve-inputs.outputs.product }} product has been updated.
+            Repository: ${{ needs.resolve-inputs.outputs.repository }}
+            Version: ${{ needs.resolve-inputs.outputs.version }}
+            Previous version: ${{ steps.diff.outputs.prev_tag }}
+            Triage reason: ${{ needs.triage.outputs.reason }}
+
+            The full diff between releases is in changes.diff.
+            The product source code is in product-repo/.
+
+            Read all skill files in skills/${{ needs.resolve-inputs.outputs.product }}/
+            (SKILL.md and everything in references/) to understand current content.
+
+            Then review the diff and update the skill accordingly.
+
+            Rules:
+            - Only update content affected by the changes
+            - Do NOT add coverage for new features unless they replace existing ones
+            - Focus on correcting APIs, config options, examples, and
+              troubleshooting scenarios that are now inaccurate
+            - Preserve the existing structure and style of the skill files
+            - If the version changed, update the version in SKILL.md frontmatter
+          claude_args: "--allowedTools Read,Write,Edit,Glob,Grep --max-turns 20"
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v8
+        with:
+          add-paths: skills/
+          title: "[${{ needs.resolve-inputs.outputs.product }}] AI-generated skill update"
+          body: |
+            AI-generated skill update based on product release.
+
+            **Repository:** ${{ needs.resolve-inputs.outputs.repository }}
+            **Version:** ${{ needs.resolve-inputs.outputs.version }}
+            **Previous version:** ${{ steps.diff.outputs.prev_tag }}
+            **Trigger:** ${{ github.event_name == 'workflow_dispatch' && 'Manual' || 'Automatic' }}
+            **Triage reason:** ${{ needs.triage.outputs.reason }}
+
+            ---
+
+            > **Please review carefully before merging.** This PR was generated by AI based on product changes.
+          labels: ai-generated
+          branch: ai-update/${{ needs.resolve-inputs.outputs.product }}
+          commit-message: "Update ${{ needs.resolve-inputs.outputs.product }} skill based on product changes"

--- a/skills/rust-best-practices/references/chapter_01.md
+++ b/skills/rust-best-practices/references/chapter_01.md
@@ -376,7 +376,7 @@ const THREE_HALVES: f32 = 1.5;
 fn q_rsqrt(number: f32 ) -> f32 {
     let mut i: i32 = number.to_bits() as i32;
     i = 0x5F375A86_i32.wrapping_sub(i >> 1);
-    let y: f32 = f32::from_bits(i as u32);
+    let y = f32::from_bits(i as u32);
     y * (THREE_HALVES - (number * 0.5 * y * y))
 }
 ```

--- a/skills/rust-best-practices/references/chapter_02.md
+++ b/skills/rust-best-practices/references/chapter_02.md
@@ -6,7 +6,7 @@ Clippy documentation can be found [here](https://doc.rust-lang.org/clippy/usage.
 
 ## 2.1 Why care about linting?
 
-Rust compiler is a powerful tool that catches many mistakes. However, some more in-depth analysis require extra tools, that is where `cargo clippy` clippy comes into to play. Clippy check for:
+Rust compiler is a powerful tool that catches many mistakes. However, some more in-depth analysis require extra tools, that is where `cargo clippy` clippy comes into to play. Clippy checks for:
 * Performance pitfalls.
 * Style issues.
 * Redundant code.
@@ -43,7 +43,7 @@ Potential additions elements to add:
 | `redundant_clone` | Detects unnecessary `clones`, has performance impact | [link (nursery + perf)](https://rust-lang.github.io/rust-clippy/master/#redundant_clone) |
 | `needless_borrow` group | Removes redundant `&` borrowing | [link (style)](https://rust-lang.github.io/rust-clippy/master/#needless_borrow) |
 | `map_unwrap_or` / `map_or` | Simplifies nested `Option/Result` handling | [`map_unwrap_or`](https://rust-lang.github.io/rust-clippy/master/#map_unwrap_or) [`unnecessary_map_or`](https://rust-lang.github.io/rust-clippy/master/#unnecessary_map_or) [`unnecessary_result_map_or_else`](https://rust-lang.github.io/rust-clippy/master/#unnecessary_result_map_or_else) |
-| `manual_ok_or` | Suggest using `.ok_or_else` instead o `match` | [link (style)](https://rust-lang.github.io/rust-clippy/master/#manual_ok_or) |
+| `manual_ok_or` | Suggest using `.ok_or_else` instead of `match` | [link (style)](https://rust-lang.github.io/rust-clippy/master/#manual_ok_or) |
 | `large_enum_variant` | Warns if an enum has very large variant which is bad for memory. Suggests `Boxing` it | [link (perf)](https://rust-lang.github.io/rust-clippy/master/#large_enum_variant) |
 | `unnecessary_wraps` | If your function always returns `Some` or `Ok`, you don't need `Option`/`Result` | [link (pedantic)](https://rust-lang.github.io/rust-clippy/master/#unnecessary_wraps) |
 | `clone_on_copy` | Catches accidental `.clone()` on `Copy` types like `u32` and `bool` | [link (complexity)](https://rust-lang.github.io/rust-clippy/master/#clone_on_copy) |
@@ -81,7 +81,7 @@ enum Message {
 
 ### Handling false positives
 
-Sometimes Clippy complains even when your code is correct, in those cases there are to solutions:
+Sometimes Clippy complains even when your code is correct, in those cases there are two solutions:
 1. Try to refactor the code, so it improves the warning.
 2. **Locally** override the lint with `#[expect(clippy::lint_name)]` and a comment with the reason.
 3. Avoid global overrides, unless it is core crate issue, a good example of this is the Bevy Engine that has a set of lints that should be allowed by default.

--- a/skills/rust-best-practices/references/chapter_04.md
+++ b/skills/rust-best-practices/references/chapter_04.md
@@ -6,9 +6,9 @@ Rust enforces a strict error handling approach, but *how* you handle them define
 
 ## 4.1 Prefer `Result`, avoid panic 🫨
 
-Rust has a powerful type that wraps wraps fallible data, [`Result<T, E>`](https://doc.rust-lang.org/std/result/), this allows us to handle Error cases according to our needs and manage the state of the application based on that.
+Rust has a powerful type that wraps fallible data, [`Result<T, E>`](https://doc.rust-lang.org/std/result/), this allows us to handle Error cases according to our needs and manage the state of the application based on that.
 
-* If you function can fail, prefer to return a `Result`:
+* If your function can fail, prefer to return a `Result`:
 ```rust
 fn divide(x: f64, y: f64) -> Result<f64, DivisionError> {
     if y == 0.0 {
@@ -117,7 +117,7 @@ Prefer using `?` over verbose alternatives like `match` chains:
 fn handle_request(req: &Request) -> Result<ValidatedRequest, MyError> {
     validate_headers(req)?;
     validate_body_format(req)?;
-    validate_validate_credentials(req)?;
+    validate_credentials(req)?;
     let body = Body::try_from(req)?;
 
     Ok(ValidatedRequest::try_from((req, body))?)
@@ -128,7 +128,7 @@ fn handle_request(req: &Request) -> Result<ValidatedRequest, MyError> {
 
 ## 4.6 Unit Test should exercise errors
 
-While many errors don't implement PartialEq and Eq, making it had to do direct assertions between them, it is possible to check the error messages with `format!` or `to_string()`, making the errors meaningful and test validated:
+While many errors don't implement PartialEq and Eq, making it hard to do direct assertions between them, it is possible to check the error messages with `format!` or `to_string()`, making the errors meaningful and test validated:
 
 ```rust
 #[test]

--- a/skills/rust-best-practices/references/chapter_05.md
+++ b/skills/rust-best-practices/references/chapter_05.md
@@ -124,14 +124,14 @@ mod test_thing_parser {
     fn lowercase_letters_are_valid() {
         assert!(
             Thing::parse("abcd").is_ok(),
-            // Works like `eprintln, format and println` macros 
+            // Works like `eprintln`, `format` and `println` macros
             "Thing parse error: {:?}", 
             Thing::parse("abcd").unwrap_err()
         );
     }
 
     #[test]
-    fn app_capital_letters_are_invalid() {
+    fn capital_letters_are_invalid() {
         assert!(Thing::parse("ABCD").is_err());
     }
 }
@@ -185,7 +185,7 @@ We will deep dive into docs at a later stage, so in this section we will just br
 
 ```rust
 /// Helper function that adds any two numeric values together.
-/// This functions reasons about which would be the correct type to parse based on the type 
+/// This function reasons about which would be the correct type to parse based on the type
 /// and the size of the numeric value.
 /// 
 /// # Examples

--- a/skills/rust-best-practices/references/chapter_08.md
+++ b/skills/rust-best-practices/references/chapter_08.md
@@ -14,7 +14,7 @@
 ## 8.2 When to use comments
 
 Use `//` comments (double slashed) when something can't be expressed clearly in code, like:
-* **Safety Guarantees**, some of done can be better expressed with code conditionals.
+* **Safety Guarantees**, some of which can be better expressed with code conditionals.
 * Workarounds or **Optimizations**.
 * Legacy or **platform-specific** behaviors. Some of them can be expressed with `#[cfg(..)]`.
 * Links to **Design Docs** or **ADRs**.
@@ -52,7 +52,7 @@ fn compute(counter: &mut usize) {
 
 ### ❌ Too long or outdated
 ```rust
-// Originally written in 2028 for some now-defunt platform
+// Originally written in 2028 for some now-defunct platform
 ```
 
 ## 8.4 Don't Write Living Documentation (living comments)
@@ -105,7 +105,7 @@ fn save_auth_user(&self) -> Result<PathBuf, MyError> {
 ## 8.6 `TODO` should become issues
 
 Don't leave `// TODO:` scattered around the codebase with no owner. Instead:
-1. File Github Issue or Jira Ticker. (Prefer github issues on public repositories).
+1. File Github Issue or Jira Ticket. (Prefer github issues on public repositories).
 2. Reference the issue in the code:
 
 ```rust


### PR DESCRIPTION
When a product repo publishes a new release and dispatches a `product-update` event (e.g. apollographql/apollo-mcp-server#696), this workflow automatically determines whether the corresponding skill needs updating and, if so, generates a PR with the corrections. The workflow can also be triggered manually for products that don't send dispatch events.

The workflow has three jobs. The resolve-inputs job normalizes inputs from either trigger, validates the skill directory exists, and auto-detects the latest stable version tag when none is provided. The triage job diffs the release and asks Claude whether any existing skill content is affected. The update-skill job asks Claude to make targeted corrections and opens a PR via `peter-evans/create-pull-request`. CODEOWNERS then routes the PR to the owning product team for review.

```mermaid
flowchart TD
    A{Trigger} -->|repository_dispatch| B[resolve-inputs]
    A -->|workflow_dispatch| B

    B --> D[triage]

    D -->|NEEDS_UPDATE| F[update-skill]
    D -->|NO_UPDATE_NEEDED| E((Skip))

    F --> G[Create PR]
```