### PR TITLE
feat: add GraphQL LSP server configuration

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://www.apollographql.com",
   "repository": "https://github.com/apollographql/skills",
   "license": "MIT",
-  "keywords": ["graphql", "apollo", "apollo-client", "apollo-connectors", "apollo-federation", "apollo-kotlin", "apollo-mcp-server", "apollo-router", "apollo-server", "graphql-operations", "graphql-schema", "rover", "rust-best-practices"]
+  "keywords": ["graphql", "apollo", "apollo-client", "apollo-connectors", "apollo-federation", "apollo-kotlin", "apollo-mcp-server", "apollo-router", "apollo-server", "graphql-operations", "graphql-schema", "graphql-lsp", "rover", "rust-best-practices"]
 }

--- a/.lsp.json
+++ b/.lsp.json
@@ -1,0 +1,12 @@
+{
+  "graphql": {
+    "command": "graphql-lsp",
+    "args": ["server", "-m", "stream"],
+    "extensionToLanguage": {
+      ".graphql": "graphql",
+      ".gql": "graphql",
+      ".graphqls": "graphql"
+    },
+    "maxRestarts": 3
+  }
+}


### PR DESCRIPTION
Adds a `.lsp.json` that configures the `graphql-lsp` language server for `.graphql`, `.gql`, and `.graphqls` files. This gives Claude Code real-time diagnostics, autocomplete, hover info, and go-to-definition when editing GraphQL files. Users need to install the binary separately (`npm install -g graphql-language-service-cli`) and have a graphql-config file in their project.