### PR TITLE
feat: sync apollo-client skill from apollo-client repo

### DIFF
--- a/.github/workflows/protect-apollo-client-skill.yml
+++ b/.github/workflows/protect-apollo-client-skill.yml
@@ -1,0 +1,35 @@
+name: Protect apollo-client skill from direct edits
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'skills/apollo-client/**'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Fail if this is not a sync PR
+        if: "!startsWith(github.head_ref, 'sync/apollo-client-skill-')"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment ${{ github.event.pull_request.number }} \
+            --repo ${{ github.repository }} \
+            --body "$(cat <<'EOF'
+          ## ⚠️ Direct edits to the \`apollo-client\` skill are not allowed
+
+          This PR modifies files under \`skills/apollo-client/\`, which is a **read-only mirror** of the skill maintained in [apollographql/apollo-client](https://github.com/apollographql/apollo-client).
+
+          Please make your changes there instead:
+          - Edit files under \`docs/agent-skills/apollo-client/\` in [apollographql/apollo-client](https://github.com/apollographql/apollo-client)
+          - Once merged, a sync workflow will automatically open a PR here
+
+          EOF
+          )"
+          echo "::error::Direct edits to skills/apollo-client/ are not allowed. See PR comment for instructions."
+          exit 1

--- a/.github/workflows/sync-apollo-client-skill.yml
+++ b/.github/workflows/sync-apollo-client-skill.yml
@@ -17,34 +17,38 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Fetch skill files from apollo-client
+        env:
+          SOURCE_SHA: ${{ inputs.source_sha }}
         run: |
-          git clone --filter=blob:none --no-checkout --depth=1 \
+          git clone --filter=blob:none --no-checkout \
             https://github.com/apollographql/apollo-client.git /tmp/apollo-client
           cd /tmp/apollo-client
           git sparse-checkout init --cone
           git sparse-checkout set docs/agent-skills/apollo-client
-          git checkout ${{ inputs.source_sha }}
+          git fetch --depth=1 origin "$SOURCE_SHA"
+          git checkout FETCH_HEAD
 
           rsync -a --delete \
             /tmp/apollo-client/docs/agent-skills/apollo-client/ \
-            ${{ github.workspace }}/skills/apollo-client/
+            "$GITHUB_WORKSPACE/skills/apollo-client/"
 
       - name: Create or update PR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SOURCE_SHA: ${{ inputs.source_sha }}
         run: |
-          BRANCH="sync/apollo-client-skill-${{ inputs.source_sha }}"
+          BRANCH="sync/apollo-client-skill-$SOURCE_SHA"
           git config user.name "Apollo GitHub Actions Bot"
           git config user.email "bot@apollographql.com"
           git checkout -b "$BRANCH"
           git add skills/apollo-client/
           git diff --cached --quiet && echo "No changes" && exit 0
-          git commit -m "sync: apollo-client skill from apollographql/apollo-client@${{ inputs.source_sha }}"
-          git push -u origin "$BRANCH"
+          git commit -m "sync: apollo-client skill from apollographql/apollo-client@$SOURCE_SHA"
+          git push --force-with-lease -u origin "$BRANCH"
           # Create PR if one doesn't exist for this branch, or skip
           gh pr create \
-            --title "sync: apollo-client skill from apollo-client@${{ inputs.source_sha }}" \
-            --body "Automated sync from [apollographql/apollo-client@${{ inputs.source_sha }}](https://github.com/apollographql/apollo-client/commit/${{ inputs.source_sha }})." \
+            --title "sync: apollo-client skill from apollo-client@$SOURCE_SHA" \
+            --body "Automated sync from [apollographql/apollo-client@${SOURCE_SHA}](https://github.com/apollographql/apollo-client/commit/${SOURCE_SHA})." \
             --base main \
             --head "$BRANCH" || true
           # Enable auto-merge

--- a/.github/workflows/sync-apollo-client-skill.yml
+++ b/.github/workflows/sync-apollo-client-skill.yml
@@ -18,20 +18,16 @@ jobs:
 
       - name: Fetch skill files from apollo-client
         run: |
-          BASE="https://raw.githubusercontent.com/apollographql/apollo-client/${{ inputs.source_sha }}/docs/agent-skills/apollo-client"
+          git clone --filter=blob:none --no-checkout --depth=1 \
+            https://github.com/apollographql/apollo-client.git /tmp/apollo-client
+          cd /tmp/apollo-client
+          git sparse-checkout init --cone
+          git sparse-checkout set docs/agent-skills/apollo-client
+          git checkout ${{ inputs.source_sha }}
 
-          mkdir -p skills/apollo-client/references
-
-          curl -fsSL "$BASE/SKILL.md" -o skills/apollo-client/SKILL.md
-
-          for ref in caching error-handling fragments integration-client \
-                     integration-nextjs integration-react-router \
-                     integration-tanstack-start mutations queries \
-                     state-management suspense-hooks troubleshooting \
-                     typescript-codegen; do
-            curl -fsSL "$BASE/references/${ref}.md" \
-              -o "skills/apollo-client/references/${ref}.md"
-          done
+          rsync -a --delete \
+            /tmp/apollo-client/docs/agent-skills/apollo-client/ \
+            ${{ github.workspace }}/skills/apollo-client/
 
       - name: Create or update PR
         env:

--- a/.github/workflows/sync-apollo-client-skill.yml
+++ b/.github/workflows/sync-apollo-client-skill.yml
@@ -14,23 +14,22 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - name: Fetch skill files from apollo-client
-        env:
-          SOURCE_SHA: ${{ inputs.source_sha }}
+      - name: Checkout apollo-client at source SHA
+        uses: actions/checkout@v6
+        with:
+          repository: apollographql/apollo-client
+          ref: ${{ inputs.source_sha }}
+          path: source
+          sparse-checkout: docs/agent-skills/apollo-client
+          sparse-checkout-cone-mode: true
+
+      - name: Mirror skill into skills/apollo-client
         run: |
-          git clone --filter=blob:none --no-checkout \
-            https://github.com/apollographql/apollo-client.git /tmp/apollo-client
-          cd /tmp/apollo-client
-          git sparse-checkout init --cone
-          git sparse-checkout set docs/agent-skills/apollo-client
-          git fetch --depth=1 origin "$SOURCE_SHA"
-          git checkout FETCH_HEAD
-
           rsync -a --delete \
-            /tmp/apollo-client/docs/agent-skills/apollo-client/ \
-            "$GITHUB_WORKSPACE/skills/apollo-client/"
+            source/docs/agent-skills/apollo-client/ \
+            skills/apollo-client/
 
       - name: Create or update PR
         env:

--- a/.github/workflows/sync-apollo-client-skill.yml
+++ b/.github/workflows/sync-apollo-client-skill.yml
@@ -1,0 +1,55 @@
+name: Sync apollo-client skill from apollo-client repo
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_sha:
+        description: 'SHA in apollographql/apollo-client to sync from'
+        required: true
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Fetch skill files from apollo-client
+        run: |
+          BASE="https://raw.githubusercontent.com/apollographql/apollo-client/${{ inputs.source_sha }}/docs/agent-skills/apollo-client"
+
+          mkdir -p skills/apollo-client/references
+
+          curl -fsSL "$BASE/SKILL.md" -o skills/apollo-client/SKILL.md
+
+          for ref in caching error-handling fragments integration-client \
+                     integration-nextjs integration-react-router \
+                     integration-tanstack-start mutations queries \
+                     state-management suspense-hooks troubleshooting \
+                     typescript-codegen; do
+            curl -fsSL "$BASE/references/${ref}.md" \
+              -o "skills/apollo-client/references/${ref}.md"
+          done
+
+      - name: Create or update PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="sync/apollo-client-skill-${{ inputs.source_sha }}"
+          git config user.name "Apollo GitHub Actions Bot"
+          git config user.email "bot@apollographql.com"
+          git checkout -b "$BRANCH"
+          git add skills/apollo-client/
+          git diff --cached --quiet && echo "No changes" && exit 0
+          git commit -m "sync: apollo-client skill from apollographql/apollo-client@${{ inputs.source_sha }}"
+          git push -u origin "$BRANCH"
+          # Create PR if one doesn't exist for this branch, or skip
+          gh pr create \
+            --title "sync: apollo-client skill from apollo-client@${{ inputs.source_sha }}" \
+            --body "Automated sync from [apollographql/apollo-client@${{ inputs.source_sha }}](https://github.com/apollographql/apollo-client/commit/${{ inputs.source_sha }})." \
+            --base main \
+            --head "$BRANCH" || true
+          # Enable auto-merge
+          gh pr merge "$BRANCH" --auto --squash || true

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,6 +3,7 @@
 !/AGENTS.md
 !/skills/
 /skills/*
-!/skills/apollo-client/
+# Apollo Client skill is maintained in another repository and synced over, don't want to format that.
+/skills/apollo-client/
 !/skills/apollo-server/
 !/skills/graphql-operations/


### PR DESCRIPTION
Sister PR at https://github.com/apollographql/apollo-client/pull/13202

## Summary

- Adds `.github/workflows/sync-apollo-client-skill.yml` — a `workflow_dispatch` workflow that syncs the `apollo-client` skill from `apollographql/apollo-client`
- Uses a sparse, blobless shallow git clone so all files under `docs/agent-skills/apollo-client/` are picked up automatically, without enumerating them explicitly
- Opens a PR against `main` and enables auto-squash-merge

## How it works

Trigger via:
```
gh workflow run sync-apollo-client-skill.yml --field source_sha=<SHA>
```

The workflow checks out `docs/agent-skills/apollo-client/` at the given SHA and `rsync`s it into `skills/apollo-client/`, then opens a PR with auto-merge enabled.

## Test plan

- [ ] Manually trigger with a known SHA from `apollographql/apollo-client`
- [ ] Confirm PR is opened with the correct diff
- [ ] Confirm auto-merge fires when CI passes
- [ ] After merge, confirm `skills/apollo-client/SKILL.md` matches the source

🤖 Generated with [Claude Code](https://claude.com/claude-code)