### PR TITLE
fix(apollo-router): reframe response caching around Cache-Control header

### DIFF
--- a/skills/apollo-router/SKILL.md
+++ b/skills/apollo-router/SKILL.md
@@ -134,7 +134,7 @@ The same principle applies to `max_height`, `max_aliases`, and `max_root_fields`
 
 ### Response Caching (v2 only, v2.6.0+)
 
-> **Security: data leakage risk.** Before generating any response cache config, you MUST ask the user which types and fields return user-specific data. All cached data is PUBLIC by default — user-specific fields cached without `scope: PRIVATE` and a `private_id` will be shared across all users.
+> **Security: data leakage risk.** Before generating any response cache config, you MUST ask the user which types and fields return user-specific data.  Cached data defaults to shared — subgraph responses without `Cache-Control: private` are visible to all users.  User-specific subgraphs must return `Cache-Control: private` and have `private_id` configured on the router.
 
 - Ask: **Which subgraphs serve user-specific data?** (e.g., accounts, profiles, carts)
 - Ask: **How do you identify users?** (JWT `sub` claim, session token, API key)
@@ -277,8 +277,8 @@ Options:
 - ONLY offer Response Caching when `ROUTER_VERSION=v2` (requires v2.6.0+)
 - ALWAYS use `${env.*}` for Redis URLs, passwords, and invalidation shared keys
 - NEVER enable `response_cache.debug: true` in production config
-- RECOMMEND combining @cacheControl (passive TTL) with @cacheTag (active invalidation) for production
-- ALWAYS ask which fields return user-specific data before generating response cache config — never assume all data is safe to cache publicly
-- ALWAYS configure `private_id` and `scope: PRIVATE` for subgraphs that serve user-specific data
+- RECOMMEND combining Cache-Control headers (passive TTL) with @cacheTag (active invalidation) for production
+- ALWAYS ask which fields return user-specific data before generating response cache config — never assume all data is safe to cache as shared
+- ALWAYS configure `private_id` for subgraphs that serve user-specific data, and ensure those subgraphs return `Cache-Control: private` (via `@cacheControl(scope: PRIVATE)` in Apollo Server, or by setting the header directly in other frameworks)
 - NEVER generate response cache config without addressing private data — if the user says "no user-specific data", confirm explicitly before proceeding
 - ALWAYS bind the invalidation endpoint to `127.0.0.1`, NEVER `0.0.0.0` in production

--- a/skills/apollo-router/references/response-caching.md
+++ b/skills/apollo-router/references/response-caching.md
@@ -9,10 +9,14 @@ Response caching enables the router to cache origin responses and reuse them acr
 - **Entity representations**: Cached independently per origin — each origin's contribution to an entity is cached separately and reusable across different queries
 - **Root query fields**: Cached as complete units (the entire response for that root field)
 
+Response caching applies to **query operations only** — mutations and subscriptions are never cached.
+
 ### Scope
 
-- **PUBLIC** (default): Data is identical for all users and shared in the cache
-- **PRIVATE**: Data is user-specific; requires `private_id` configuration to cache per-user
+Scope is determined by the `Cache-Control` header the subgraph returns.  (The router docs call these "PUBLIC" and "PRIVATE" — we use "shared" and "private" here because they describe the actual behavior more clearly.)
+
+- **Shared** (default — no `private` directive in the header): Data is identical for all users and stored in a single shared cache entry
+- **Private** (`Cache-Control: private`): Data is user-specific; requires `private_id` configuration to cache per-user in separate entries
 
 ### Mixed TTLs
 
@@ -20,17 +24,21 @@ When an origin response contains multiple entity representations, the router use
 
 ## Security
 
-### Data leakage risk: PUBLIC scope is the default
+### Data leakage risk: cached data defaults to shared
 
-> **Security: cross-user data leakage.** All cached data uses PUBLIC scope by default. Any subgraph response cached without `scope: PRIVATE` and a configured `private_id` is shared across ALL users. If user-specific fields (profile data, preferences, bookmarks, cart contents) are cached as PUBLIC, any user can receive another user's data.
+> **Security: cross-user data leakage.** Caching requires opt-in — subgraphs must return a `Cache-Control` header for the router to cache anything.  But once a response IS cached, it defaults to PUBLIC scope (shared across all users).  If a subgraph returns `Cache-Control: max-age=300` for user-specific data without also including `private`, that data is shared across all users.
 
-This is the highest-severity risk in response caching. Misconfiguration means silently serving one user's private data to others.
+The risk is not "everything gets cached" — it's "data that IS cached defaults to shared."  If a subgraph opts into caching but forgets to mark user-specific responses as `private`, those responses are silently served to other users.
 
 ### Before enabling response caching, you MUST:
 
 1. **Identify every field that returns user-specific data** — ask the user which types and fields vary per user. Do not guess. Common examples: user profiles, preferences, bookmarks, cart contents, order history, notifications, permissions.
 
-2. **Mark user-specific fields with `scope: PRIVATE`** in the subgraph schema:
+2. **Ensure user-specific responses include `Cache-Control: private`** — how you do this depends on your subgraph framework:
+   - **Apollo Server**: use `@cacheControl(scope: PRIVATE)` in your schema
+   - **Other servers**: set the header directly, e.g., `Cache-Control: private, max-age=60`
+
+   Apollo Server example:
    ```graphql
    type User @key(fields: "id") {
      id: ID!
@@ -40,14 +48,14 @@ This is the highest-severity risk in response caching. Misconfiguration means si
    }
    ```
 
-3. **Configure `private_id`** for every subgraph that serves PRIVATE-scoped data:
+3. **Configure `private_id`** for every subgraph that serves private-scoped data:
    ```yaml
    response_cache:
      enabled: true
      subgraph:
        subgraphs:
          accounts:
-           private_id: "user_id"  # REQUIRED for PRIVATE scope to work
+           private_id: "user_id"  # REQUIRED for private scope to work
    ```
 
 4. **Extract the user identifier** from the request (e.g., JWT `sub` claim) via a Rhai script:
@@ -63,7 +71,7 @@ This is the highest-severity risk in response caching. Misconfiguration means si
    }
    ```
 
-**What happens if `private_id` is missing:** When a subgraph returns a PRIVATE-scoped response but no `private_id` is configured, the router cannot identify the user. The cache is bypassed entirely for those requests — no data leakage occurs, but you get no caching benefit. However, if a field *should* be PRIVATE but is not marked as such in the schema, it will be cached as PUBLIC and shared across users.
+**What happens if `private_id` is missing:** When a subgraph returns `Cache-Control: private` but no `private_id` is configured, the router cannot identify the user.  The cache is bypassed entirely for those requests — no data leakage occurs, but you get no caching benefit.  However, if a response *should* be private but the subgraph doesn't include `private` in the `Cache-Control` header, it will be cached as shared and served to all users.
 
 ### Additional security requirements
 
@@ -90,7 +98,7 @@ response_cache:
   subgraph:
     all:
       enabled: true
-      ttl: 5m  # Required: fallback TTL when responses lack Cache-Control headers
+      ttl: 5m  # Required: used when Cache-Control header lacks max-age
       redis:
         urls: ["${env.CACHE_REDIS_URL:-redis://localhost:6379}"]
 ```
@@ -141,40 +149,25 @@ Format: `redis[s][-cluster]://[[username:]password@]host[:port][/database]`
 
 Clustered URLs can include `?node=host1:port1&node=host2:port2` query parameters or be provided as a YAML array of URLs.
 
-## Schema Directives
+## Cache-Control Header
 
-### @cacheControl(maxAge, scope, inheritMaxAge)
+The router determines caching behavior from the `Cache-Control` HTTP response header returned by each subgraph.  It does not read schema directives directly — only the headers they produce.
 
-Controls the `Cache-Control` header the subgraph returns. The router reads that header to determine TTLs — the directive itself does not directly affect what the router caches.
+### What the router reads
 
-First, add the directive definition to your subgraph schema:
+| Header directive | Effect |
+|-----------------|--------|
+| `max-age=N` | Cache for N seconds (overrides the configured fallback `ttl`) |
+| `private` | Data is user-specific — requires `private_id` to cache per-user |
+| `no-store` | Do not cache this response |
 
-```graphql
-enum CacheControlScope {
-  PUBLIC
-  PRIVATE
-}
+If the subgraph returns **no `Cache-Control` header at all**, the response is **not cached** — even when a fallback `ttl` is configured.  The fallback TTL only applies when a `Cache-Control` header is present but lacks `max-age`.
 
-directive @cacheControl(
-  maxAge: Int
-  scope: CacheControlScope
-  inheritMaxAge: Boolean
-) on FIELD_DEFINITION | OBJECT | INTERFACE | UNION
-```
+When a subgraph response contains multiple entities with different TTLs, the router uses the minimum `max-age` across all of them.
 
-Apollo Server recognizes this directive automatically. For other servers, consult your server's documentation for `Cache-Control` header support.
+### How to emit Cache-Control headers
 
-**Type-level** — sets a default TTL for all fields returning this type:
-
-```graphql
-type Product @key(fields: "id") @cacheControl(maxAge: 240) {
-  id: ID!
-  name: String!
-  price: Int
-}
-```
-
-**Field-level** — overrides type-level settings:
+**Apollo Server** — use the `@cacheControl` directive in your subgraph schema.  Apollo Server translates this into `Cache-Control` headers automatically.  See the [Apollo Server caching documentation](https://www.apollographql.com/docs/apollo-server/performance/caching) for the full directive reference (field-level vs. type-level TTLs, `inheritMaxAge`, dynamic TTLs in resolvers, etc.).
 
 ```graphql
 type Product @key(fields: "id") @cacheControl(maxAge: 240) {
@@ -185,11 +178,13 @@ type Product @key(fields: "id") @cacheControl(maxAge: 240) {
 }
 ```
 
-When a query requests fields with different TTLs, the origin returns `Cache-Control` with the minimum `max-age`.
+**Other GraphQL servers** (Java, Go, Python, etc.) — set the `Cache-Control` header directly in your HTTP response using whatever mechanism your framework provides.  For example: `Cache-Control: public, max-age=240` or `Cache-Control: private, max-age=60`.
+
+> The `@cacheControl` directive is Apollo Server-specific.  The router only sees the HTTP header — how your subgraph produces that header is an implementation detail.
 
 ### @cacheTag(format)
 
-Tags cached data for active invalidation. Introduced in Federation v2.12. Import it via:
+Tags cached data for active invalidation.  This is a federation directive (not Apollo Server-specific) — the router reads it from the composed supergraph schema.  Introduced in Federation v2.12.  Import it via:
 
 ```graphql
 extend schema
@@ -199,11 +194,12 @@ extend schema
   )
 ```
 
+> `@cacheTag` controls invalidation tags, not whether data is cached.  The subgraph must still return `Cache-Control` headers (see above) for caching to take effect.
+
 **On entities** — use `{$key.<field>}` for dynamic tags based on entity keys:
 
 ```graphql
 type User @key(fields: "id")
-  @cacheControl(maxAge: 60)
   @cacheTag(format: "user-{$key.id}")
   @cacheTag(format: "user") {
   id: ID!
@@ -216,7 +212,6 @@ type User @key(fields: "id")
 ```graphql
 type Query {
   postsByUser(userId: ID!): [Post!]!
-    @cacheControl(maxAge: 120)
     @cacheTag(format: "posts-user-{$args.userId}")
 }
 ```
@@ -231,9 +226,8 @@ type Query {
 ### Passive (TTL-based)
 
 Data automatically expires based on:
-1. `@cacheControl(maxAge: N)` directives in the subgraph schema (translated to `Cache-Control` headers)
-2. `Cache-Control` headers returned by the origin
-3. The configured `ttl` fallback (used when no `Cache-Control` header or `max-age` is present)
+1. `Cache-Control: max-age=N` headers returned by the subgraph (set via `@cacheControl` in Apollo Server, or emitted directly by other servers)
+2. The configured `ttl` fallback (used when a `Cache-Control` header is present but lacks `max-age`)
 
 The router uses the minimum TTL across all components in a response.
 
@@ -318,7 +312,7 @@ If tags depend on runtime data (not entity keys or field args), set them in the 
 
 ### Private data caching
 
-> **Security: see the [Security section](#security) above.** You MUST configure `private_id` and mark user-specific fields with `scope: PRIVATE` before enabling caching on subgraphs that serve user-specific data. Failure to do so causes cross-user data leakage.
+> **Security: see the [Security section](#security) above.** You MUST configure `private_id` and ensure user-specific subgraph responses include `Cache-Control: private` before enabling caching on subgraphs that serve user-specific data.  Failure to do so causes cross-user data leakage.
 
 For full configuration, Rhai script examples, and the security checklist, see [Security](#security).
 
@@ -479,7 +473,7 @@ telemetry:
 | Selector | Values | Description |
 |----------|--------|-------------|
 | `response_cache` | `hit` or `miss` | Number of cache hits/misses for a subgraph request |
-| `response_cache_status` | `hit`, `partial_hit`, `miss`, `status` | Cache status for the subgraph request |
+| `response_cache_status` | `hit`, `partial_hit`, `miss`, or `status` | When set to `hit`/`partial_hit`/`miss`: returns a count.  When set to `status`: returns the status string (`hit`, `partial_hit`, or `miss`) as an attribute value. |
 | `response_cache_control` | `max_age`, `scope`, `no_store` | Data from the computed `Cache-Control` header |
 
 Example — log uncached subgraph responses:

--- a/skills/apollo-router/references/troubleshooting.md
+++ b/skills/apollo-router/references/troubleshooting.md
@@ -264,8 +264,8 @@ supergraph:
 ### Response Cache Misses
 
 1. **Check subgraph Cache-Control headers**: origin must return `Cache-Control` without `no-store`
-2. **Verify @cacheControl directives**: fields/types need `@cacheControl(maxAge: N)` in subgraph schemas
-3. **Check scope**: `scope: PRIVATE` requires `private_id` to be configured
+2. **Verify Cache-Control headers**: subgraph responses need `Cache-Control: max-age=N` (via `@cacheControl` in Apollo Server, or set directly in other frameworks)
+3. **Check scope**: `Cache-Control: private` requires `private_id` to be configured on the router
 4. **Verify Redis connectivity**: check `apollo.router.cache.redis.errors` metric
 5. **Enable cache debugger** (dev only): set `response_cache.debug: true` and use Apollo Sandbox to inspect cache state
 

--- a/skills/apollo-router/templates/v2/sections/response-caching.yaml
+++ b/skills/apollo-router/templates/v2/sections/response-caching.yaml
@@ -1,6 +1,6 @@
 # Response Caching — v2 (v2.6.0+)
 # Requires Redis. Entity-level and root-field caching for subgraph responses.
-# Use @cacheControl and @cacheTag directives in subgraph schemas to control behavior.
+# Subgraphs must return Cache-Control headers for caching to take effect.
 # See references/response-caching.md for full setup, invalidation, and observability.
 response_cache:
   enabled: true
@@ -11,6 +11,15 @@ response_cache:
       redis:
         urls:
           - ${env.CACHE_REDIS_URL:-redis://localhost:6379}
+    # SECURITY: If any subgraph serves user-specific data, configure private_id
+    # so the router can cache per-user.  The subgraph must also return
+    # Cache-Control: private (via @cacheControl(scope: PRIVATE) in Apollo Server,
+    # or by setting the header directly in other frameworks).
+    # subgraphs:
+    #   accounts:
+    #     private_id: "user_id"
+    #
+    # Remove the invalidation block below if not using active invalidation.
       invalidation:
         enabled: true
         shared_key: ${env.INVALIDATION_SHARED_KEY}

--- a/skills/apollo-router/validation/checklist.md
+++ b/skills/apollo-router/validation/checklist.md
@@ -44,10 +44,10 @@ Run through this checklist after generating a `router.yaml` to catch common mist
 ### Security
 
 - [ ] **User-specific fields identified**: Confirmed with the user which fields return per-user data
-- [ ] **PRIVATE scope set**: All user-specific fields use `@cacheControl(scope: PRIVATE)` in subgraph schemas
-- [ ] **private_id configured**: Every subgraph serving PRIVATE-scoped data has `private_id` set
+- [ ] **Private scope set**: User-specific subgraph responses include `Cache-Control: private` (via `@cacheControl(scope: PRIVATE)` in Apollo Server, or by setting the header directly in other frameworks)
+- [ ] **private_id configured**: Every subgraph serving private-scoped data has `private_id` set
 - [ ] **User identifier extracted**: Rhai script or coprocessor populates the `private_id` context key from auth token
-- [ ] **No unprotected user data**: Verified that no user-specific field is cached as PUBLIC (the default)
+- [ ] **No unprotected user data**: Verified that no user-specific response is cached without `Cache-Control: private`
 - [ ] **Debug mode disabled** (production): `response_cache.debug` is absent or `false`
 - [ ] **Invalidation endpoint not publicly exposed** (production): bind to `127.0.0.1`, not `0.0.0.0`
 - [ ] **Invalidation shared key uses env var**: `${env.INVALIDATION_SHARED_KEY}`


### PR DESCRIPTION
Review feedback for #37 — targeting `response-caching` so this merges into the PR.

## What changed

- `references/response-caching.md` — replaced the "Schema Directives" section with "Cache-Control Header" and lead with the HTTP header the router actually reads.  `@cacheControl` is now framed as Apollo Server-specific with a pointer to the Apollo Server caching docs for the full directive reference.  Removed `@cacheControl` from `@cacheTag` examples (different concern — invalidation tags are a federation directive, independent of caching opt-in).  Clarified that mutations and subscriptions are never cached.  Explained the shared/private vs PUBLIC/PRIVATE terminology choice.  Clarified `response_cache_status: status` is a config mode that returns the status string as an attribute.
- `templates/v2/sections/response-caching.yaml` — added a commented `private_id` placeholder with security context; noted the invalidation block is optional so it can be removed when the user opts out.
- `validation/checklist.md` and `SKILL.md` — updated ground rules and checklist items to reference the `Cache-Control` header rather than only the Apollo Server directive.
- `references/troubleshooting.md` — updated the cache-miss entries to reference `Cache-Control` headers directly.

## Why

The router reads `Cache-Control` HTTP response headers — it does not read schema directives directly.  `@cacheControl` is Apollo Server's way of producing that header declaratively; other subgraph frameworks (Java, Go, Python, etc.) emit the header themselves.  The original framing presented the directive as the caching mechanism, which would mislead anyone running a non-Apollo-Server subgraph.

Also tightened the "public by default" framing after verifying behavior against the router source (`apollo-router/src/plugins/response_cache/cache_control.rs`): responses without a `Cache-Control` header are *not* cached, even when a fallback `ttl` is configured.  The data-leakage scenario is narrower than the original text implied — it only applies to data that is *explicitly* cached by the subgraph but missing `private` — but still load-bearing enough to warrant the security section.

Context: #37