### PR TITLE
docs(apollo-router): expand observability and Redis deployment guidance

### DIFF
--- a/skills/apollo-router/references/response-caching.md
+++ b/skills/apollo-router/references/response-caching.md
@@ -149,6 +149,34 @@ Format: `redis[s][-cluster]://[[username:]password@]host[:port][/database]`
 
 Clustered URLs can include `?node=host1:port1&node=host2:port2` query parameters or be provided as a YAML array of URLs.
 
+## Redis deployment
+
+This skill configures the router to talk to Redis, but does not cover deploying or operating Redis itself.  Plan for these operational concerns separately.
+
+### Topology and high availability
+
+For production workloads, use Redis with **replica sets** — a primary with one or more replicas and automated failover.  Most managed Redis services provide this natively (AWS ElastiCache replication groups, Azure Cache for Redis, GCP Memorystore Standard, Upstash, Redis Enterprise, etc.), handling failover transparently at the DNS level so a standalone URL continues to work.
+
+- **Single-node** (`redis://`, `rediss://`) — fine for local development; not recommended for production.
+- **Replica set** (still `redis://` or `rediss://`, pointing at the primary endpoint) — the typical production topology.
+- **Redis Cluster** (`redis-cluster://`, `rediss-cluster://`) — for horizontal sharding when cache size exceeds a single node's memory.  Most response cache workloads do not need Cluster; start with a replica set and only move to Cluster if you outgrow it.
+
+Keep Redis colocated with routers (same VPC, same region).  Every cache fetch is in the request path, so network latency directly affects user-facing response time.
+
+### Eviction policy
+
+Configure Redis with `allkeys-lru` (or `allkeys-lfu`) eviction.  With `noeviction` (Redis's default), writes fail once memory is full and the router logs insert errors instead of caching new responses.  `volatile-*` policies also work since the router sets TTLs on every entry.
+
+### Graceful degradation
+
+When Redis is unreachable, the router bypasses the cache and sends requests directly to subgraphs — your graph keeps serving traffic without caching benefits, but it does not fail.  This is the default behavior.
+
+If you set `required_to_start: true`, the router refuses to start without a Redis connection.  Use this only when you cannot tolerate a cache-cold deployment.
+
+### Cold start
+
+After a router restart with empty Redis (or a Redis flush), the first wave of requests will all be cache misses, producing a spike of subgraph traffic.  Plan for this when rolling out caching to a high-traffic graph — consider a gradual rollout or pre-warming if your origins are sensitive to the spike.
+
 ## Cache-Control Header
 
 The router determines caching behavior from the `Cache-Control` HTTP response header returned by each subgraph.  It does not read schema directives directly — only the headers they produce.
@@ -399,6 +427,20 @@ response_cache:
 ```
 
 ## Observability
+
+### What to watch
+
+Four signals tell you whether response caching is healthy.  If you set up a dashboard for this feature, start with these:
+
+1. **Cache hit rate** — derived from `apollo.router.response.cache` (counter that records hits and misses for subgraph requests; filter by cache status to compute hit / (hit + miss)).  No universal target — depends on TTLs and traffic shape — but watch for sudden drops, which usually mean subgraphs stopped emitting `Cache-Control` headers or Redis is misbehaving.
+
+2. **Redis error rate** — `apollo.router.cache.redis.errors` (counter, tagged by error type: auth, timeout, io, etc.).  Any sustained non-zero rate warrants investigation.
+
+3. **Cache fetch and insert latency** — `apollo.router.operations.response_cache.fetch` and `apollo.router.operations.response_cache.insert` (histograms, seconds).  The p99 should be well under your subgraph response time, otherwise the cache is *adding* latency rather than removing it.  If p99 climbs, check Redis CPU/memory and the `pool_size` setting.
+
+4. **Reconnection rate** — `apollo.router.response_cache.reconnection`.  Spikes indicate network instability or Redis restarts.
+
+For invalidation specifically, also watch `apollo.router.operations.response_cache.invalidation.error` (failed invalidations leave stale data) and `apollo.router.operations.response_cache.invalidation.duration` (slow invalidations indicate Redis pressure).
 
 ### Metrics
 


### PR DESCRIPTION
Follow-up to #53 — targeting `response-caching` so this merges into #37.

## What changed

Two focused additions to `references/response-caching.md`:

- **Observability: "What to watch"** — a prioritized list of the four primary signals (cache hit rate, Redis error rate, fetch/insert p99, reconnection rate) naming the specific metrics by name so an LLM generating a dashboard or alert config knows exactly which to reach for.  Also flags the invalidation-specific metrics worth watching alongside (`apollo.router.operations.response_cache.invalidation.error` and `.duration`).
- **Redis deployment** — a new section explicitly scoped as "not covered by this skill, but here's what to consider."  Covers topology (single-node / replica set / Redis Cluster with replica sets as the typical production pattern), eviction policy (`allkeys-lru` to avoid write failures when memory is full), graceful degradation when Redis is unreachable, and cold-start spikes to subgraphs after a router restart with empty Redis.

## Why

The original PR's observability coverage was exhaustive in listing metrics and trace attributes, but didn't tell the LLM *which ones to actually watch*.  A skill that enumerates metrics without prioritizing them leaves the LLM to guess — these four signals are the ones that catch real problems.

On Redis: setting up and operating Redis itself is out of scope for a skill that generates router config, but a few of the operational concerns (eviction policy, failover topology, cold-start behavior) are load-bearing enough that an LLM generating a Redis-backed caching config without hinting at them could steer the user toward a configuration that works fine in dev but falls over in production.  Framed explicitly as "here's what to consider — not what this skill covers."

Context: #37, #53