### PR TITLE
ci: enforce bumping plugin versions

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo-skills",
   "description": "Agent skills for AI coding agents working with Apollo GraphQL tools and technologies",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "Apollo GraphQL",
     "email": "opensource@apollographql.com"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,44 @@ jobs:
           done
           echo "✅ All $count skills discoverable by Claude Code plugin"
 
+  version-check:
+    runs-on: ubuntu-latest
+    # Run only on pull requests so we can diff against the base branch
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Require plugin version bump when plugin content changes
+        run: |
+          base="origin/${{ github.base_ref }}"
+          changed=$(git diff --name-only "$base"...HEAD -- \
+            'skills/**' \
+            'commands/**' \
+            'agents/**' \
+            'hooks/**' \
+            '.claude-plugin/plugin.json')
+          if [ -z "$changed" ]; then
+            echo "✅ No plugin content changed; plugin version bump not required."
+            exit 0
+          fi
+          head_v=$(jq -r .version .claude-plugin/plugin.json)
+          base_v=$(git show "$base":.claude-plugin/plugin.json | jq -r .version)
+          if [[ ! "$head_v" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "❌ plugin.json#version is not semver: '$head_v'"
+            exit 1
+          fi
+          if [ "$head_v" = "$base_v" ] || ! printf '%s\n%s\n' "$base_v" "$head_v" | sort -V -C; then
+            echo "❌ Plugin content changed but .claude-plugin/plugin.json#version did not strictly increase ($base_v → $head_v)."
+            echo "Bump it (drives /plugin update behavior). Changed paths:"
+            echo "$changed"
+            exit 1
+          fi
+          echo "✅ plugin.json version bumped: $base_v → $head_v"
+
   test-remote:
     runs-on: ubuntu-latest
     # Run only on push to main

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,3 +55,13 @@ Skills should be validated against the Agent Skills specification at https://age
 2. Add reference files in `skills/<skill-name>/references/` as needed
 3. Update `README.md` to document the new skill (follow existing patterns)
 4. Ensure consistency with existing skills' frontmatter format
+
+## Releasing / Versioning
+
+The only version that requires thought is **plugin** (`.claude-plugin/plugin.json#version`) — bump on every PR that changes `skills/`, `commands/`, `agents/`, `hooks/`, or `plugin.json` itself. This is what `claude plugin update apollo-skills@apollo-marketplace` checks; without a bump, `claude plugin update` reports users as already on the latest version and they will not pull your changes. Fresh installs are unaffected. CI's `version-check` job enforces it.
+
+Use semver: patch for fixes/refactors, minor for added skills, major for breaking removals.
+
+`marketplace.json#metadata.version` is intentionally pinned. This repo has a single plugin and no marketplace structure changes are anticipated; if that ever changes (a second plugin, a rename, moving sources), bump it manually then.
+
+`package.json#version` is npm metadata for a private package; ignore it.


### PR DESCRIPTION
<!-- https://apollographql.atlassian.net/browse/AMS-475 -->

Resolves #56. `claude plugin update apollo-skills@apollo-marketplace` was reporting users as already on the latest version because `plugin.json#version` had been pinned at `1.0.0` since the repo's first commit despite many merged skill changes. Already-installed users were never receiving updates unless they re-installed it.

This PR:

- Bumps `.claude-plugin/plugin.json#version` to `1.1.0`.
- Adds a CI `version-check` job that fails any PR which changes `skills/`, `commands/`, `agents/`, `hooks/`, or `plugin.json` itself without bumping `plugin.json#version`. This prevents the same drift from happening again.
- Documents the rule in `AGENTS.md`.