### PR TITLE
feat: integrate gh skill cli with auto-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,64 @@
+name: Release
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Ensure gh skill is available
+        run: |
+          if ! gh skill --help >/dev/null 2>&1; then
+            echo "Installing latest gh CLI..."
+            sudo mkdir -p -m 755 /etc/apt/keyrings
+            curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg >/dev/null
+            echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list >/dev/null
+            sudo apt-get update -qq
+            sudo apt-get install -y -qq gh
+          fi
+          gh --version | head -1
+
+      - name: Read plugin version
+        id: version
+        run: |
+          v=$(jq -r .version .claude-plugin/plugin.json)
+          if [[ ! "$v" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "❌ plugin.json#version is not semver: '$v'"
+            exit 1
+          fi
+          echo "tag=v${v}" >> "$GITHUB_OUTPUT"
+          echo "Tag will be: v${v}"
+
+      - name: Skip if release already exists
+        id: gate
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "${{ steps.version.outputs.tag }}" >/dev/null 2>&1; then
+            echo "ℹ️ ${{ steps.version.outputs.tag }} already released, skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "✅ ${{ steps.version.outputs.tag }} is available"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish skills
+        if: steps.gate.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh skill publish --tag "${{ steps.version.outputs.tag }}"

--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -60,3 +60,29 @@ jobs:
 
           echo ""
           echo "✅ All skills validated successfully"
+
+  gh-skill-validate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Ensure gh skill is available
+        run: |
+          if ! gh skill --help >/dev/null 2>&1; then
+            echo "Installing latest gh CLI..."
+            sudo mkdir -p -m 755 /etc/apt/keyrings
+            curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg >/dev/null
+            echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list >/dev/null
+            sudo apt-get update -qq
+            sudo apt-get install -y -qq gh
+          fi
+          gh --version | head -1
+
+      - name: Validate with gh skill
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh skill publish --dry-run

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,8 @@ allowed-tools: Bash(tool:*) Read Write Edit Glob Grep
 
 Skills should be validated against the Agent Skills specification at https://agentskills.io/specification
 
+Validate locally with `gh skill publish --dry-run` (or `skills-ref validate skills/<name>`) before opening a PR.
+
 ## Adding a New Skill
 
 1. Create `skills/<skill-name>/SKILL.md` with proper frontmatter
@@ -58,10 +60,12 @@ Skills should be validated against the Agent Skills specification at https://age
 
 ## Releasing / Versioning
 
-The only version that requires thought is **plugin** (`.claude-plugin/plugin.json#version`) — bump on every PR that changes `skills/`, `commands/`, `agents/`, `hooks/`, or `plugin.json` itself. This is what `claude plugin update apollo-skills@apollo-marketplace` checks; without a bump, `claude plugin update` reports users as already on the latest version and they will not pull your changes. Fresh installs are unaffected. CI's `version-check` job enforces it.
+Two versions matter.
 
-Use semver: patch for fixes/refactors, minor for added skills, major for breaking removals.
+`.claude-plugin/plugin.json#version` is what `claude plugin update` checks. Bump it whenever you touch `skills/`, `commands/`, `agents/`, `hooks/`, or `plugin.json` itself, otherwise existing users won't see the change. CI catches forgotten bumps. New installs always pull the latest content regardless.
 
-`marketplace.json#metadata.version` is intentionally pinned. This repo has a single plugin and no marketplace structure changes are anticipated; if that ever changes (a second plugin, a rename, moving sources), bump it manually then.
+The gh skill release tag is automatic. Pushes to `main` run a workflow that reads the plugin version and tags a matching `vX.Y.Z` if it doesn't exist yet. That's what `gh skill install apollographql/skills <name>@vX.Y.Z` pins to.
 
-`package.json#version` is npm metadata for a private package; ignore it.
+Use semver: patch for fixes, minor for new skills, major when you remove or rename one.
+
+You can ignore `marketplace.json#metadata.version` and `package.json#version`. The marketplace barely changes for a single-plugin repo, and `package.json` is npm metadata we don't publish.

--- a/README.md
+++ b/README.md
@@ -65,6 +65,39 @@ Once installed, skills are available as namespaced slash commands:
 | `/apollo-skills:rust-best-practices` | Rust best practices — idiomatic Rust following Apollo conventions |
 | `/apollo-skills:skill-creator` | Skill creator — guide for creating new Apollo skills |
 
+## GitHub CLI
+
+You can also install skills with the [GitHub CLI](https://cli.github.com/) using `gh skill` (preview):
+
+```bash
+# Install one skill into the current project for Claude Code
+gh skill install apollographql/skills apollo-client --agent claude-code
+
+# Install at user scope (available everywhere)
+gh skill install apollographql/skills apollo-client --agent claude-code --scope user
+
+# Pin to a specific release
+gh skill install apollographql/skills apollo-client@v1.0.0 --agent claude-code
+
+# Preview a skill before installing
+gh skill preview apollographql/skills apollo-client
+```
+
+`--agent` supports many hosts beyond Claude Code (Cursor, Codex, Gemini CLI, GitHub Copilot, and more); run `gh skill install --help` for the full list.
+
+## Releases
+
+Releases are tagged with semver and published automatically whenever a content change is merged to `main`. The full list lives at [github.com/apollographql/skills/releases](https://github.com/apollographql/skills/releases).
+
+| Install path | What you get |
+|---|---|
+| `gh skill install apollographql/skills <name>` | Latest tagged release |
+| `gh skill install apollographql/skills <name>@v1.0.0` | Pinned to a specific release |
+| `npx skills add apollographql/skills@<name>` | Latest content from `main` (no tag) |
+| Claude Code plugin (`claude plugin install`) | Latest plugin version (auto-updates via `claude plugin update`) |
+
+If you need stability, pin via `gh skill install …@vX.Y.Z`. For the freshest content, the other paths track `main` HEAD directly.
+
 ## Available Skills
 
 ### apollo-connectors


### PR DESCRIPTION
<!-- https://apollographql.atlassian.net/browse/AMS-475 -->

Adds [gh skill](https://github.blog/changelog/2026-04-16-manage-agent-skills-with-github-cli/) as a third install path alongside `npx skills` and the Claude Code plugin marketplace. The repo was already spec-compliant (flat `skills/*/SKILL.md` layout, valid frontmatter, no install metadata in source), so this is mostly wiring rather than restructuring.

A new `gh-skill-validate` CI job runs `gh skill publish --dry-run` on every PR, complementing the existing `skills-ref` validator. Both have to pass.

The bigger piece is `release.yml`. It fires on every push to `main`, reads `plugin.json#version` (CI-enforced since #59), and publishes a matching `vX.Y.Z` tag via `gh skill publish` if one doesn't already exist. Pushes that don't bump the plugin version are no-ops, so cutting a release stops being a separate step: bump `plugin.json` in your PR, merge, and the tag appears.