### PR TITLE
Rover schema exploration

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo-skills",
   "description": "Agent skills for AI coding agents working with Apollo GraphQL tools and technologies",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "author": {
     "name": "Apollo GraphQL",
     "email": "opensource@apollographql.com"

--- a/skills/rover/SKILL.md
+++ b/skills/rover/SKILL.md
@@ -6,12 +6,13 @@ description: >
   (2) composing supergraph schemas locally or via GraphOS,
   (3) running local supergraph development with rover dev,
   (4) validating schemas with check and lint commands,
-  (5) configuring Rover authentication and environment.
+  (5) configuring Rover authentication and environment,
+  (6) exploring or searching a graph's schema for agent-driven discovery (rover schema describe / rover schema search).
 license: MIT
 compatibility: Node.js v18+, Linux/macOS/Windows
 metadata:
   author: apollographql
-  version: "1.0.1"
+  version: "1.1.0"
 allowed-tools: Bash(rover:*) Bash(npm:*) Bash(npx:*) Read Write Edit Glob Grep
 ---
 
@@ -51,6 +52,29 @@ rover --version
 rover config whoami
 ```
 
+## Explore a Graph's Schema (start here for schema questions)
+
+To answer "what's in this graph?", find a field, or write a query against a GraphOS graph, **fetch the API schema and pipe it into `rover schema`** — this keeps the SDL out of your context and returns only what you need:
+
+```bash
+# What can I query? (compact overview)
+rover graph fetch <graph@variant> | rover schema describe -
+
+# Find a field by concept/keyword (returns the path from a root operation)
+rover graph fetch <graph@variant> | rover schema search - "<keyword>"
+
+# Zoom into one type or field
+rover graph fetch <graph@variant> | rover schema describe - --coord <Type.field> --depth 1
+```
+
+Three rules that keep this correct:
+
+- Use **`rover graph fetch`** (the API schema) — **not** `rover supergraph fetch` (that returns composition SDL with federation internals like `join__`/`link__`).
+- **Pipe** it in — never run `rover graph fetch` alone and read the raw SDL (a large schema floods your context; that's exactly what `rover schema` avoids).
+- The `schema` commands read **piped SDL, not a graph ref** — `rover schema describe <graph@variant>` fails; you must fetch first and pipe.
+
+Full reference, ranking rules, and the save-once pattern: [Schema Exploration](#schema-exploration-for-agents) and [references/schema.md](references/schema.md).
+
 ## Core Commands Overview
 
 | Command | Description | Use Case |
@@ -61,6 +85,8 @@ rover config whoami
 | `rover supergraph compose` | Compose supergraph locally | Local testing |
 | `rover dev` | Local supergraph development | Development workflow |
 | `rover graph publish` | Publish monograph schema | Non-federated graphs |
+| `rover schema describe` | Explore a schema by coordinate; **takes SDL via stdin/file, not a graph ref** — pipe from `rover graph fetch` | Agent schema discovery |
+| `rover schema search` | Search a schema by keyword; **takes SDL via stdin/file, not a graph ref** — pipe from `rover graph fetch` | Agent schema discovery |
 
 ## Graph Reference Format
 
@@ -147,6 +173,8 @@ rover supergraph compose --config supergraph.yaml > supergraph.graphql
 rover supergraph fetch my-graph@production
 ```
 
+> This returns the **supergraph SDL** (federation directives + `join__`/`link__` internals) — use it for composition/router work. To **explore what you can query** or write an operation, use `rover graph fetch` (the API schema) instead — see [Explore a Graph's Schema](#explore-a-graphs-schema-start-here-for-schema-questions).
+
 ## Local Development with `rover dev`
 
 Start a local Router with automatic schema composition:
@@ -166,6 +194,43 @@ rover dev --graph-ref my-graph@staging --supergraph-config local.yaml
 rover dev --supergraph-config supergraph.yaml --mcp
 ```
 
+## Schema Exploration (for Agents)
+
+`rover schema describe` and `rover schema search` let an agent explore a schema **without loading the full SDL into context** — that is the entire point of these commands.
+
+> ⚠️ **Never read the raw SDL into context.** Running `rover graph fetch <ref>` (or `rover graph introspect <url>`) on its own prints the entire schema — hundreds to tens of thousands of lines — straight into your context, which defeats the purpose of these commands. **Always pipe fetch output into `rover schema describe`/`search`**: the SDL flows through stdin and only the compact overview/results reach you. (Fetching to a file is fine when the user actually wants the SDL.)
+>
+> These commands also take SDL on **stdin or a file, NOT a graph ref** — you can't pass `graph@variant` to them. Fetch first, then pipe:
+>
+> ```bash
+> ❌ rover schema describe my-graph@current             # error: looks for a file named that
+> ❌ rover graph fetch my-graph@current                 # dumps the full SDL into your context
+> ✅ rover graph fetch my-graph@current | rover schema describe -
+> ```
+
+To explore a graph in GraphOS, fetch its schema and pipe it in. **Use `rover graph fetch` (the API schema) for "what can I query?" exploration** — it omits federation internals. Reach for `rover supergraph fetch` only when you need composition details (`join__`/`link__` types, subgraph structure):
+
+```bash
+# Overview of a GraphOS graph
+rover graph fetch my-graph@current | rover schema describe -
+
+# Find fields by keyword (results include paths from root operations)
+rover graph fetch my-graph@current | rover schema search - "playback"
+
+# Zoom into a coordinate, expanding referenced types one level
+rover graph fetch my-graph@current | rover schema describe - --coord <Type.field> --depth 1
+```
+
+**`search` vs `describe`:** reach for `rover schema search` first when matching a concept or keyword and you don't yet know the field name — it finds **nested** fields and shows the path from a root operation. The `describe` overview lists only root fields, so `search` is how you locate fields buried deeper. Use `describe` for the overview or once you know the type/field coordinate.
+
+This enables a closed-loop workflow — search → describe → write a query — with no MCP server setup. See [Schema Exploration](references/schema.md) for the full command reference, ranking rules, and the save-once pattern for large schemas.
+
+**Running the generated operation:** Rover does **not** execute queries — it only manages and inspects schemas. To actually run a generated query you need the graph's endpoint:
+
+- **Single-subgraph graph:** `rover subgraph list <graph@variant>` prints the **Routing Url** — send the query there with `curl`.
+- **Multi-subgraph / federated:** the client endpoint is the **router** URL (find it in GraphOS Studio; for a GraphOS cloud router, `rover cloud config fetch <graph@variant>`), not the per-subgraph routing URLs.
+- Don't try to discover the endpoint via the GraphOS Platform API — Rover keeps the API key in its profile/keychain, not `$APOLLO_KEY`, so ad-hoc API calls will come back unauthenticated.
+
 ## Reference Files
 
 Detailed documentation for specific topics:
@@ -174,6 +239,7 @@ Detailed documentation for specific topics:
 - [Graphs](references/graphs.md) - monograph commands (non-federated)
 - [Supergraphs](references/supergraphs.md) - compose, fetch, config format
 - [Dev](references/dev.md) - rover dev for local development
+- [Schema Exploration](references/schema.md) - describe, search, agent schema discovery workflows
 - [Configuration](references/configuration.md) - install, auth, env vars, profiles
 
 ## Common Patterns
@@ -223,3 +289,5 @@ rover subgraph fetch my-graph@production --name products --format plain
 - USE `--format json` when parsing output programmatically
 - SPECIFY `federation_version` explicitly in supergraph.yaml for reproducibility
 - USE `rover subgraph introspect` to extract schemas from running services
+- USE `rover schema search` / `rover schema describe` (piped from a `fetch`) to explore large schemas instead of loading the full SDL into context
+- NEVER fetch a full schema into context just to explore it — pipe `rover graph fetch`/`introspect` into `rover schema describe`/`search` (a bare `fetch` is only for when the user wants the SDL file itself)

--- a/skills/rover/references/schema.md
+++ b/skills/rover/references/schema.md
@@ -1,0 +1,192 @@
+# Rover Schema Commands
+
+Commands for **exploring** a GraphQL schema: get a structured overview, zoom into a single type or field, or search for types and fields by keyword. These are designed for agent-driven schema discovery — an agent can search → describe → write a query in a closed loop, without loading a huge SDL into its context.
+
+> **Local and offline — these take SDL, not a graph ref.** `rover schema describe` and `rover schema search` read SDL from a **file or from stdin only**; they do not call GraphOS and need no authentication. Unlike other rover commands, passing a graph ref fails:
+>
+> ```bash
+> ❌ rover schema describe my-graph@current
+> ✅ rover graph fetch my-graph@current | rover schema describe -
+> ```
+>
+> **Pipe — don't read the raw SDL.** Running `rover graph fetch`/`introspect` on its own dumps the whole schema into context; always pipe it into `describe`/`search` so only the compact result reaches you. To explore a graph that lives in GraphOS, fetch its schema first and pipe it in — see [GraphOS Schema Exploration](#graphos-schema-exploration).
+
+## schema describe
+
+Describe a schema by type, field, or directive. With no coordinate it prints a schema overview; with `--coord` it zooms into a single element.
+
+```bash
+# Schema overview (type counts, root operations)
+rover schema describe schema.graphql
+
+# Describe one type
+rover schema describe schema.graphql --coord User
+
+# Describe one field
+rover schema describe schema.graphql --coord User.posts
+
+# Expand referenced types one level deep
+rover schema describe schema.graphql --coord User --depth 1
+
+# Describe a directive
+rover schema describe schema.graphql --coord @deprecated
+
+# Raw SDL excerpt for the coordinate instead of a description
+rover schema describe schema.graphql --coord User --view sdl
+
+# Read from stdin (omit the file or pass -)
+cat schema.graphql | rover schema describe
+cat schema.graphql | rover schema describe - --coord User
+
+# Machine-readable output
+rover schema describe schema.graphql --coord User --format json
+```
+
+**Coordinate forms** (apollo-compiler `SchemaCoordinate` syntax):
+
+| Form | Matches |
+|------|---------|
+| `Type` | object, interface, enum, input, scalar, or union |
+| `Type.field` | field on an object/interface, or value on an enum/input |
+| `Type.field(arg:)` | argument on a field |
+| `@directive` | directive definition |
+| `@directive(arg:)` | argument on a directive |
+
+**Options:**
+| Option | Description |
+|--------|-------------|
+| `[FILE]` | SDL file to read. Omit or pass `-` to read from stdin. |
+| `--coord, -c <COORDINATE>` | Schema coordinate to inspect. Omit for a full overview. |
+| `--depth, -d <N>` | Inline referenced type definitions up to N levels deep (types/fields only; default `0`). |
+| `--include-deprecated` | Show deprecated fields and enum values. |
+| `--view, -v <VIEW>` | Output view: `description` (default) or `sdl`. |
+| `--format json` | Machine-readable JSON output. Works on the subcommand or top-level (`rover --format json schema describe ...`). |
+
+> Field coordinates automatically include the field's argument and return types, so a single `--coord Type.field` call gives an agent enough context to use it.
+
+## schema search
+
+Find types and fields by keyword. Each result is a schema coordinate plus the path(s) from a root operation that reach it — enough to write a query from a single search.
+
+```bash
+# Single keyword
+rover schema search schema.graphql email
+
+# Multiple terms — all must match (AND)
+rover schema search schema.graphql "create post"
+
+# Comma-separated clauses — any clause matches (OR)
+rover schema search schema.graphql "email, displayName"
+
+# Limit results (default 10)
+rover schema search schema.graphql author --limit 20
+
+# Include deprecated members
+rover schema search schema.graphql id --include-deprecated
+
+# Read from stdin (FILE must be -)
+cat schema.graphql | rover schema search - user
+
+# Machine-readable output
+rover --format json schema search schema.graphql email
+```
+
+Example output:
+
+```
+1 result for "email"
+
+User.email — The user's email address
+  field  ·  via Query.user, Mutation.createPost -> Post.author
+```
+
+The `via` line lists complete paths from a `Query`/`Mutation` root to the match, with intermediate types included — so an agent can turn a result straight into an operation.
+
+**Ranking** — results are ordered by match tier (strongest first), then alphabetically by coordinate. Names are split on camelCase / snake_case and matching is case-insensitive:
+
+| Tier | Matches when the term… |
+|------|------------------------|
+| Exact | is a substring of the name or a name token |
+| Stem | shares an English stem with a name token |
+| Fuzzy | is within one edit of a name token (terms ≥ 4 chars; shorter terms must match a token exactly) |
+| Description | appears in the SDL description, with no name match |
+
+**Options:**
+| Option | Description |
+|--------|-------------|
+| `<FILE>` | SDL file to read (required). Pass `-` to read from stdin. |
+| `<TERMS>...` | Search terms (required). Space-separated = all match (AND); comma-separated = OR clauses. |
+| `--limit, -n <N>` | Maximum number of results (default `10`). |
+| `--include-deprecated` | Include deprecated fields and enum values. |
+| `--format json` | Machine-readable JSON output. Works on the subcommand or top-level. |
+
+## GraphOS Schema Exploration
+
+`schema describe` and `schema search` work on local SDL, so to explore a graph registered in GraphOS you fetch its schema first and pipe it in. Any `rover ... fetch` command prints SDL to stdout in its default (`plain`) format, so it pipes directly.
+
+> **Authentication:** the fetch step calls GraphOS and needs auth (`rover config auth` or `APOLLO_KEY`) and a graph reference (`graph@variant`). The `schema describe` / `schema search` step is local and needs neither.
+
+**Fetch sources:**
+
+| Command | Returns |
+|---------|---------|
+| `rover graph fetch <GRAPH_REF>` | API schema (client-facing) — **best default** for discovering what clients can query; omits federation internals |
+| `rover subgraph fetch <GRAPH_REF> --name <NAME>` | one subgraph's schema (with federation directives) |
+| `rover supergraph fetch <GRAPH_REF>` | full supergraph SDL — includes federation internals (`join__`/`link__` types); use only for composition/federation inspection |
+
+**Pipe directly (no temp file):**
+
+```bash
+# Overview of a GraphOS graph
+rover graph fetch my-graph@current | rover schema describe
+
+# Find fields by keyword
+rover graph fetch my-graph@current | rover schema search - "playback"
+
+# Zoom into a coordinate from the search results
+rover graph fetch my-graph@current | rover schema describe - --coord <Type.field> --depth 1
+```
+
+**Save once, explore repeatedly** (more efficient for large schemas):
+
+```bash
+rover supergraph fetch my-graph@current > schema.graphql
+rover schema search   schema.graphql "playback"
+rover schema describe schema.graphql --coord <Type.field> --depth 1
+```
+
+A local running server works too, via introspection:
+
+```bash
+rover subgraph introspect http://localhost:4001/graphql | rover schema search - "user"
+```
+
+## Closed-Loop Agent Workflow
+
+With these two commands an agent can go from a vague request to an executable query with no human guidance:
+
+```bash
+# 1. What's in this graph?
+rover graph fetch mcp-showcase-spotify@current | rover schema describe
+
+# 2. Find the relevant fields — returns Player.currentlyPlaying
+#    via Query.me -> CurrentUser.player
+rover graph fetch mcp-showcase-spotify@current | rover schema search - "currently playing"
+
+# 3. Expand the type on the returned path
+rover graph fetch mcp-showcase-spotify@current | rover schema describe - --coord Player.currentlyPlaying --depth 1
+
+# 4. Write and run the query using the `via` path from step 2.
+```
+
+When piping, prefer the save-once pattern in step 2–3 if you run several searches against the same graph — it avoids re-fetching.
+
+**Running it (step 4):** Rover does not execute operations. Get the endpoint — `rover subgraph list <graph@variant>` shows the **Routing Url** for a single-subgraph graph, or use the router URL from GraphOS Studio (for a cloud router, `rover cloud config fetch <graph@variant>`) for a federated one — then send the query with `curl`. Don't hunt for it via the Platform API; the API key lives in Rover's profile/keychain, not `$APOLLO_KEY`.
+
+## Tips
+
+- **`search` vs `describe`:** use `search` to find a field by concept/keyword — it surfaces **nested** fields with their path from a root operation. Use `describe` for the overview or a known coordinate. The overview lists only root fields, so `search` is how you locate nested ones (e.g. `search "service provider"` → `Launch.launchServiceProvider`, which no overview shows).
+- These commands are offline; only the `fetch`/`introspect` step needs network and auth.
+- Use `--coord Type.field --depth 1` to pull a field plus its argument and return types in one call.
+- Use `rover --format json schema search ...` (or `describe`) when a script or tool consumes the output.
+- For natural-language / semantic search (vector-based), see the `apollo-mcp-server` skill — `rover schema search` is keyword/fuzzy (lexical) matching.


### PR DESCRIPTION
<!-- https://apollographql.atlassian.net/browse/AMS-501 -->

Rover recently released `rover schema describe` and `rover schema search` in versions 0.38 to 0.40. These features help the rover skill use them for agent-driven schema exploration without needing an MCP server. Since both commands read SDL from a file or stdin instead of a graph reference, the documentation focuses on the fetch → pipe → explore pattern with the command `rover graph fetch <ref> | rover schema search/describe -`. 

I noticed two common mistakes agents made during testing: they sometimes passed a graph reference directly to the schema commands, and they reached for `supergraph fetch` when they actually needed `graph fetch`, which is for the API schema. The update includes a new `references/schema.md`, an updated `SKILL.md` with a new use case, version 1.1.0, Core Commands rows, a "Schema Exploration" section with guidance on anti-patterns, and a ground rule. The plugin version has also been bumped to 1.2.4.

# Testing

Test it the way it'll actually be used: in Claude Code with this skill loaded. No GraphOS login needed.

Setup: have this branch's `skills/rover` available to Claude Code (symlink into a project's `.claude/skills/`, or install the plugin from this branch), Rover ≥ 0.40 on PATH, and `rover config auth` set up with access to the `dale@space` graph (or substitute any `graph@variant` you can fetch). First endpoint call may cold-start (~20–30s).

1. **Discovery** — Prompt: *"What can I query in the `dale@space` graph?"*
   - Expect: the rover skill loads **on its own**; the agent runs `rover graph fetch dale@space | rover schema describe -` and summarizes the operations. It must **not** dump the full SDL and must **not** use `supergraph fetch`.

2. **Search for a nested field** — Prompt: *"Which field tells me the company launching each rocket?"*
   - Expect: `rover graph fetch dale@space | rover schema search - "service provider"` → names `Launch.launchServiceProvider` (a **nested** field surfaced by `search` with its path from a root op — not in the overview). Verifies the search-first guidance.

3. **Generate + run** — Prompt: *"Write and run a query for the next 5 upcoming launches with their name, date, and launching company."*
   - Expect: the agent generates `{ upcomingLaunches(ordering: "net") { results { name net launchServiceProvider { name } } } }`, **discovers the endpoint itself** (e.g. `rover subgraph list dale@space` → routing URL), runs it via `curl`, and returns real data — mission names (e.g. `Falcon 9 Block 5 | Starlink …`) with providers (e.g. `SpaceX`). It should note the endpoint ignores `limit` and slice to 5 client-side.