### PR TITLE
docs: clarify federation link version is a floor

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo-skills",
   "description": "Agent skills for AI coding agents working with Apollo GraphQL tools and technologies",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "author": {
     "name": "Apollo GraphQL",
     "email": "opensource@apollographql.com"

--- a/skills/apollo-federation/SKILL.md
+++ b/skills/apollo-federation/SKILL.md
@@ -12,7 +12,7 @@ license: MIT
 compatibility: Works with any Federation 2.x compatible subgraph library (Apollo Server, GraphQL Yoga, etc.)
 metadata:
   author: apollographql
-  version: "1.0.1"
+  version: "1.0.2"
 allowed-tools: Bash(rover:*) Read Write Edit Glob Grep
 ---
 

--- a/skills/apollo-federation/SKILL.md
+++ b/skills/apollo-federation/SKILL.md
@@ -30,17 +30,13 @@ extend schema
         import: ["@key", "@shareable", "@external", "@requires", "@provides"])
 ```
 
-Import only the directives your subgraph uses. The version shown (`v2.12`) is an
-example — check the [currently supported versions](references/composition.md#federation-versions-floor-vs-composition)
-before copying, rather than anchoring on whatever number appears here.
+Import only the directives your subgraph uses. The version shown (`v2.12`) is
+illustrative — check the [Federation changelog](https://www.apollographql.com/docs/graphos/schema-design/federated-schemas/reference/versions)
+for currently supported versions before copying it verbatim.
 
-> **A subgraph's `@link` version is a floor, not the composition version.** It
-> declares the *minimum* federation version required for the directives that
-> subgraph uses — not what version the graph is composed at. The composition
-> version is set separately (`federation_version` in `supergraph.yaml` locally,
-> or the variant's Build Pipeline setting in GraphOS) and only needs to be ≥
-> every subgraph's floor. A subgraph pinned below the composition version is
-> normal, not a bug. See [Federation versions](references/composition.md#federation-versions-floor-vs-composition).
+> A subgraph's `@link` version is a floor, not the composition version — see
+> [Federation versions](references/composition.md#federation-versions-floor-vs-composition)
+> for the full explanation.
 
 ## Core Directives Quick Reference
 

--- a/skills/apollo-federation/SKILL.md
+++ b/skills/apollo-federation/SKILL.md
@@ -30,7 +30,17 @@ extend schema
         import: ["@key", "@shareable", "@external", "@requires", "@provides"])
 ```
 
-Import only the directives your subgraph uses.
+Import only the directives your subgraph uses. The version shown (`v2.12`) is an
+example — check the [currently supported versions](references/composition.md#federation-versions-floor-vs-composition)
+before copying, rather than anchoring on whatever number appears here.
+
+> **A subgraph's `@link` version is a floor, not the composition version.** It
+> declares the *minimum* federation version required for the directives that
+> subgraph uses — not what version the graph is composed at. The composition
+> version is set separately (`federation_version` in `supergraph.yaml` locally,
+> or the variant's Build Pipeline setting in GraphOS) and only needs to be ≥
+> every subgraph's floor. A subgraph pinned below the composition version is
+> normal, not a bug. See [Federation versions](references/composition.md#federation-versions-floor-vs-composition).
 
 ## Core Directives Quick Reference
 

--- a/skills/apollo-federation/references/composition.md
+++ b/skills/apollo-federation/references/composition.md
@@ -21,8 +21,9 @@ not a bug** — you do not need to bump every subgraph's `@link` to match the
 composition version.
 
 > The version numbers used throughout this skill (e.g. `v2.12`, `=2.9.0`) are
-> illustrative. Check the currently supported federation versions before pinning
-> one, rather than copying whatever number appears in an example.
+> illustrative. Check the [Federation changelog](https://www.apollographql.com/docs/graphos/schema-design/federated-schemas/reference/versions)
+> for currently supported versions before pinning one, rather than copying
+> whatever number appears in an example.
 
 ### UNKNOWN_FEDERATION_LINK_VERSION at server startup
 

--- a/skills/apollo-federation/references/composition.md
+++ b/skills/apollo-federation/references/composition.md
@@ -2,6 +2,45 @@
 
 Rules for composing subgraph schemas into a supergraph, with error codes and fixes.
 
+## Federation Versions: Floor vs. Composition
+
+A subgraph's `@link(url: ".../federation/vX.Y")` version is the **minimum**
+version required for the directives that subgraph uses — **not** a declaration
+of what version the graph is composed at. Two versions are in play, and they are
+set independently:
+
+- **Subgraph floor** — the `@link` version in each subgraph's SDL. It just needs
+  to cover the directives that subgraph actually uses.
+- **Composition version** — set separately, once, for the whole build:
+  `federation_version` in `supergraph.yaml` for local composition, or the
+  variant's **Build Pipeline** setting in GraphOS.
+
+The only rule between them is: the composition version must be ≥ every
+subgraph's floor. A subgraph sitting below the composition version is **normal,
+not a bug** — you do not need to bump every subgraph's `@link` to match the
+composition version.
+
+> The version numbers used throughout this skill (e.g. `v2.12`, `=2.9.0`) are
+> illustrative. Check the currently supported federation versions before pinning
+> one, rather than copying whatever number appears in an example.
+
+### UNKNOWN_FEDERATION_LINK_VERSION at server startup
+
+If `buildSubgraphSchema()` throws `UNKNOWN_FEDERATION_LINK_VERSION` **at server
+startup** (not at `rover subgraph publish` / composition time), that's a
+client-library lag — **not** a sign that GraphOS doesn't support the version.
+
+Composition (Rust, in Rover/Router) and the JS schema-building library you build
+your subgraph with (`@apollo/subgraph`) have independent, separately-versioned
+understandings of which federation versions exist, and the JS side can trail
+behind. So a version can compose fine in GraphOS yet be rejected by your local
+subgraph server.
+
+**Fix:** lower that subgraph's `@link` to the highest version your library
+actually recognizes (upgrade `@apollo/subgraph` if you need a newer one). The
+composition version can still be pinned higher — remember the floor-vs-composition
+distinction above.
+
 ## Entity Validation
 
 Entities must have valid `@key` definitions that can be resolved across subgraphs.

--- a/skills/rover/SKILL.md
+++ b/skills/rover/SKILL.md
@@ -12,7 +12,7 @@ license: MIT
 compatibility: Node.js v18+, Linux/macOS/Windows
 metadata:
   author: apollographql
-  version: "1.1.1"
+  version: "1.1.2"
 allowed-tools: Bash(rover:*) Bash(npm:*) Bash(npx:*) Read Write Edit Glob Grep
 ---
 

--- a/skills/rover/SKILL.md
+++ b/skills/rover/SKILL.md
@@ -162,6 +162,12 @@ subgraphs:
       subgraph_url: http://localhost:4002/graphql
 ```
 
+`federation_version` here is the **composition version** — it only needs to be ≥
+each subgraph's `@link` floor, so subgraphs pinned to a lower version compose
+fine. If a subgraph server throws `UNKNOWN_FEDERATION_LINK_VERSION` at startup,
+that's a client-library lag, not a composition problem. See the apollo-federation
+skill's [Federation versions](../apollo-federation/references/composition.md#federation-versions-floor-vs-composition).
+
 Compose:
 ```bash
 rover supergraph compose --config supergraph.yaml > supergraph.graphql


### PR DESCRIPTION
This clarifies that a subgraph's `@link` federation version is the minimum version required for the directives it uses, not the version the graph is composed with. That distinction had previously sent a reader down a long debugging path. The `apollo-federation` skill now explains this floor-versus-composition-version rule up front. `composition.md` also adds a dedicated Federation Versions section and a troubleshooting entry for `UNKNOWN_FEDERATION_LINK_VERSION` at server startup, which is caused by a lag in the JavaScript library, not by a composition failure. The hardcoded `v2.12` and `=2.9.0` examples are now clearly marked as illustrative rather than normative. The `rover` skill also includes a one-line cross-reference so the version guidance stays in one place.